### PR TITLE
Family plan dev

### DIFF
--- a/kor-react/public/index.html
+++ b/kor-react/public/index.html
@@ -1,46 +1,81 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <link rel="icon" type="image/png" sizes="32x32" href="%PUBLIC_URL%/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="%PUBLIC_URL%/favicon-16x16.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="%PUBLIC_URL%/apple-touch-icon.png">
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="32x32"
+      href="%PUBLIC_URL%/favicon-32x32.png"
+    />
+    <link
+      rel="icon"
+      type="image/png"
+      sizes="16x16"
+      href="%PUBLIC_URL%/favicon-16x16.png"
+    />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="%PUBLIC_URL%/apple-touch-icon.png"
+    />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#2e4053" />
-    
+
     <!-- Primary Meta Tags -->
     <title>KOR - Never Miss Bike Maintenance Again | Bike Tracking App</title>
-    <meta name="title" content="KOR - Never Miss Bike Maintenance Again | Bike Tracking App">
+    <meta
+      name="title"
+      content="KOR - Never Miss Bike Maintenance Again | Bike Tracking App"
+    />
     <meta
       name="description"
       content="Track your bike's component wear automatically with KOR. Integrated with Strava, our intelligent maintenance app alerts you before parts fail. Free download for iOS & Android."
     />
-    <meta name="keywords" content="bike maintenance, bicycle maintenance, strava integration, bike parts tracking, cycling app, mountain biking, road cycling, bike shop software">
-    <meta name="author" content="KOR Cycling Team">
-    
+    <meta
+      name="keywords"
+      content="bike maintenance, bicycle maintenance, strava integration, bike parts tracking, cycling app, mountain biking, road cycling, bike shop software"
+    />
+    <meta name="author" content="KOR Cycling Team" />
+
     <!-- Open Graph / Facebook -->
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://jmrcycling.com/">
-    <meta property="og:title" content="KOR - Never Miss Bike Maintenance Again">
-    <meta property="og:description" content="Track your bike's component wear automatically with KOR. Integrated with Strava, our intelligent maintenance app alerts you before parts fail.">
-    <meta property="og:image" content="%PUBLIC_URL%/images/KOR_app_Logo.png">
-    
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://jmrcycling.com/" />
+    <meta
+      property="og:title"
+      content="KOR - Never Miss Bike Maintenance Again"
+    />
+    <meta
+      property="og:description"
+      content="Track your bike's component wear automatically with KOR. Integrated with Strava, our intelligent maintenance app alerts you before parts fail."
+    />
+    <meta property="og:image" content="%PUBLIC_URL%/images/KOR_app_Logo.png" />
+
     <!-- Twitter -->
-    <meta property="twitter:card" content="summary_large_image">
-    <meta property="twitter:url" content="https://jmrcycling.com/">
-    <meta property="twitter:title" content="KOR - Never Miss Bike Maintenance Again">
-    <meta property="twitter:description" content="Track your bike's component wear automatically with KOR. Integrated with Strava, our intelligent maintenance app alerts you before parts fail.">
-    <meta property="twitter:image" content="%PUBLIC_URL%/images/KOR_app_Logo.png">
-    
+    <meta property="twitter:card" content="summary_large_image" />
+    <meta property="twitter:url" content="https://jmrcycling.com/" />
+    <meta
+      property="twitter:title"
+      content="KOR - Never Miss Bike Maintenance Again"
+    />
+    <meta
+      property="twitter:description"
+      content="Track your bike's component wear automatically with KOR. Integrated with Strava, our intelligent maintenance app alerts you before parts fail."
+    />
+    <meta
+      property="twitter:image"
+      content="%PUBLIC_URL%/images/KOR_app_Logo.png"
+    />
+
     <!-- Canonical URL -->
     <link rel="canonical" href="https://jmrcycling.com/" />
-    
+
     <!-- Preconnect to external domains -->
-    <link rel="preconnect" href="https://js.chargebee.com">
-    <link rel="preconnect" href="https://formspree.io">
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="preconnect" href="https://js.chargebee.com" />
+    <link rel="preconnect" href="https://formspree.io" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
@@ -56,7 +91,10 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <!-- Chargebee JavaScript SDK -->
-    <script src="https://js.chargebee.com/v2/chargebee.js" data-cb-site="jmrcycling-test"></script>
+    <script
+      src="https://js.chargebee.com/v2/chargebee.js"
+      data-cb-site="jmrcycling-test"
+    ></script>
     <!-- <script src="https://js.chargebee.com/v2/chargebee.js" data-cb-site="jmrcycling"></script> -->
   </head>
   <body>

--- a/kor-react/src/App.tsx
+++ b/kor-react/src/App.tsx
@@ -23,7 +23,6 @@ import LegacyParamsDemo from './components/demo/LegacyParamsDemo';
 import ParameterTestPage from './components/demo/ParameterTestPage';
 import PersonalSignIn from './components/personal/PersonalSignIn';
 import OAuthAuthorize from './components/oauth/OAuthAuthorize';
-import FamilyPlanSignUp from './components/pages/FamilyPlanSignUp';
 import './styles/styles.css';
 
 function App() {

--- a/kor-react/src/App.tsx
+++ b/kor-react/src/App.tsx
@@ -21,10 +21,12 @@ import LegacyParamsDemo from './components/demo/LegacyParamsDemo';
 import ParameterTestPage from './components/demo/ParameterTestPage';
 import PersonalSignIn from './components/personal/PersonalSignIn';
 import OAuthAuthorize from './components/oauth/OAuthAuthorize';
- import './styles/styles.css';
+import FamilyPlanSignUp from './components/pages/FamilyPlanSignUp';
+import './styles/styles.css';
 
 function App() {
-  const domain = process.env.REACT_APP_AUTH0_DOMAIN || 'dev-kor-shop.us.auth0.com';
+  const domain =
+    process.env.REACT_APP_AUTH0_DOMAIN || 'dev-kor-shop.us.auth0.com';
   const clientId = process.env.REACT_APP_AUTH0_CLIENT_ID || 'your-client-id';
   const audience = process.env.REACT_APP_AUTH0_AUDIENCE;
 
@@ -36,21 +38,21 @@ function App() {
       currentUrl: window.location.href,
       timestamp: new Date().toISOString()
     });
-    
+
     initGA();
     initPostHog();
-    
+
     console.log('✨ [App] App initialization complete');
   }, [domain, clientId, audience]);
 
   // Create auth params object - NO redirect_uri here to allow dynamic redirects in components
   const authParams: any = {};
-  
+
   // Only include audience if it's configured
   if (audience) {
     authParams.audience = audience;
   }
-  
+
   console.log('🔧 [App] Auth0Provider configuration:', {
     domain,
     clientId,
@@ -66,30 +68,37 @@ function App() {
     >
       <Router>
         <GoogleAnalytics />
-        <div className="App">
+        <div className='App'>
           <Header />
           <main>
             <Routes>
-              <Route path="/" element={<Home />} />
-              <Route path="/our-app" element={<OurApp />} />
-              <Route path="/our-story" element={<OurStory />} />
-              <Route path="/sign-up" element={<SignUp />} />
-              <Route path="/personal-plans" element={<PersonalPlans />} />
-              <Route path="/personal/signin" element={<PersonalSignIn />} />
-              <Route path="/contact" element={<Contact />} />
-              <Route path="/faq" element={<FAQ />} />
-              <Route path="/qr-guide" element={<QrGuide />} />
-              <Route path="/oauth/authorize/*" element={<OAuthAuthorize />} />
-              <Route path="/shop/login" element={<ShopLogin />} />
-              <Route path="/shop/dashboard" element={<ShopDashboard />} />
-              <Route path="/shop/settings" element={<ShopSettings />} />
+              <Route path='/' element={<Home />} />
+              <Route path='/our-app' element={<OurApp />} />
+              <Route path='/our-story' element={<OurStory />} />
+              <Route path='/sign-up' element={<SignUp />} />
+              <Route path='/personal-plans' element={<PersonalPlans />} />
+              <Route path='/personal/signin' element={<PersonalSignIn />} />
+              <Route path='/family-plan-signup' element={<FamilyPlanSignUp />} />
+              <Route path='/contact' element={<Contact />} />
+              <Route path='/faq' element={<FAQ />} />
+              <Route path='/qr-guide' element={<QrGuide />} />
+              <Route path='/oauth/authorize/*' element={<OAuthAuthorize />} />
+              <Route path='/shop/login' element={<ShopLogin />} />
+              <Route path='/shop/dashboard' element={<ShopDashboard />} />
+              <Route path='/shop/settings' element={<ShopSettings />} />
               {/* Legacy-compatible routes */}
-              <Route path="/shop/signin" element={<ShopSignIn />} />
-              <Route path="/shop_tools/signin" element={<ShopSignIn />} />
-              <Route path="/shop_tools/dashboard" element={<ShopDashboard />} />
+              <Route path='/shop/signin' element={<ShopSignIn />} />
+              <Route path='/shop_tools/signin' element={<ShopSignIn />} />
+              <Route path='/shop_tools/dashboard' element={<ShopDashboard />} />
               {/* Development/testing routes */}
-              <Route path="/demo/legacy-params" element={<LegacyParamsDemo />} />
-              <Route path="/demo/parameter-test" element={<ParameterTestPage />} />
+              <Route
+                path='/demo/legacy-params'
+                element={<LegacyParamsDemo />}
+              />
+              <Route
+                path='/demo/parameter-test'
+                element={<ParameterTestPage />}
+              />
             </Routes>
           </main>
           <Footer />

--- a/kor-react/src/App.tsx
+++ b/kor-react/src/App.tsx
@@ -10,6 +10,8 @@ import OurStory from './components/pages/OurStory';
 import OurApp from './components/pages/OurApp';
 import SignUp from './components/pages/SignUp';
 import PersonalPlans from './components/pages/PersonalPlans';
+import FamilyPlanPricing from './components/pages/FamilyPlanPricing';
+import FamilyPlanSignUp from './components/pages/FamilyPlanSignUp';
 import Contact from './components/pages/Contact';
 import FAQ from './components/pages/FAQ';
 import QrGuide from './components/pages/QrGuide';
@@ -76,6 +78,8 @@ function App() {
               <Route path="/sign-up" element={<SignUp />} />
               <Route path="/personal-plans" element={<PersonalPlans />} />
               <Route path="/personal/signin" element={<PersonalSignIn />} />
+              <Route path="/family-plan-pricing" element={<FamilyPlanPricing />} />
+              <Route path="/family-plan-signup" element={<FamilyPlanSignUp />} />
               <Route path="/contact" element={<Contact />} />
               <Route path="/faq" element={<FAQ />} />
               <Route path="/qr-guide" element={<QrGuide />} />

--- a/kor-react/src/components/pages/FamilyPlanPricing.tsx
+++ b/kor-react/src/components/pages/FamilyPlanPricing.tsx
@@ -1,0 +1,244 @@
+import React, { useEffect } from 'react';
+import StructuredData from '../common/StructuredData';
+
+// Declare Chargebee as a global variable for TypeScript
+declare global {
+  interface Window {
+    Chargebee: any;
+  }
+}
+
+const FamilyPlanPricing: React.FC = () => {
+  useEffect(() => {
+    // Initialize Chargebee when component mounts
+    if (window.Chargebee) {
+      const site = process.env.REACT_APP_CHARGEBEE_SITE || 'jmrcycling';
+      const publishableKey = process.env.REACT_APP_CHARGEBEE_PUBLISHABLE_KEY;
+
+      const initConfig: any = { site };
+      if (publishableKey) {
+        initConfig.publishableKey = publishableKey;
+      }
+
+      window.Chargebee.init(initConfig);
+
+      const isProduction =
+        process.env.REACT_APP_ENVIRONMENT === 'production' ||
+        process.env.NODE_ENV === 'production';
+      if (!publishableKey) {
+        if (isProduction) {
+          console.warn(
+            'Chargebee publishable key is not configured. Some checkout features may not work in production.'
+          );
+        } else {
+          console.log(
+            'Chargebee publishable key not set - assuming development mode.'
+          );
+        }
+      }
+
+      console.log(
+        `Chargebee initialized with site: ${site}${publishableKey ? ' and publishable key' : ''}`
+      );
+    } else {
+      console.warn('Chargebee not loaded - using development fallback mode');
+    }
+  }, []);
+
+  const baseUrl = process.env.REACT_APP_SITE_URL || 'https://jmrcycling.com';
+
+  const handleSubscription = (billingCycle: string) => {
+    console.log(`Attempting to subscribe to Family - ${billingCycle}`);
+
+    // Debug environment variables
+    console.log('Environment check:', {
+      NODE_ENV: process.env.NODE_ENV,
+      REACT_APP_ENVIRONMENT: process.env.REACT_APP_ENVIRONMENT,
+      REACT_APP_CHARGEBEE_PUBLISHABLE_KEY:
+        process.env.REACT_APP_CHARGEBEE_PUBLISHABLE_KEY
+    });
+
+    // Check if we're in development mode or Chargebee isn't configured
+    const isDevelopment =
+      process.env.NODE_ENV === 'development' ||
+      process.env.REACT_APP_ENVIRONMENT === 'development';
+    const isTestKey =
+      process.env.REACT_APP_CHARGEBEE_PUBLISHABLE_KEY ===
+      'test_publishable_key';
+
+    console.log('Dev mode checks:', { isDevelopment, isTestKey });
+
+    // ALWAYS bypass Chargebee in dev mode or with test key - check this FIRST
+    if (isDevelopment || isTestKey) {
+      console.log(
+        '🧪 [FamilyPlanPricing] Dev mode detected - bypassing Chargebee'
+      );
+      const confirmed = window.confirm(
+        `Development Mode:\n\nYou're trying to subscribe to:\nFamily Plan - ${billingCycle}\n\nThis would normally open Chargebee checkout.\n\nClick OK to simulate successful subscription, or Cancel to abort.`
+      );
+
+      if (confirmed) {
+        // Simulate successful subscription in development
+        alert(
+          'Simulated successful subscription! Redirecting to family sign in...'
+        );
+        window.location.href =
+          '/family-plan-signup?success=true&plan_type=family&billing=' +
+          encodeURIComponent(billingCycle);
+      }
+      return;
+    }
+
+    // Production path - only if NOT in dev mode
+    if (!window.Chargebee) {
+      alert(
+        'Payment system is not available. Please try again in a moment or contact support.'
+      );
+      return;
+    }
+
+    // Map plan types to Chargebee plan IDs
+    const planMap: { [key: string]: string } = {
+      Monthly: 'Family-USD-Monthly',
+      Yearly: 'Family-USD-Yearly'
+    };
+
+    const planId = planMap[billingCycle];
+
+    if (!planId) {
+      console.error('Plan ID not found for:', billingCycle);
+      alert('Plan configuration error. Please contact support.');
+      return;
+    }
+
+    try {
+      // Initialize Chargebee instance if not already done
+      const cbInstance = window.Chargebee.getInstance();
+
+      if (!cbInstance) {
+        alert(
+          'Payment system initialization error. Please refresh the page and try again.'
+        );
+        return;
+      }
+
+      // Open Chargebee checkout
+      cbInstance.openCheckout({
+        hostedPage: () => {
+          // This should return a hosted page object from your backend
+          // For now, we'll attempt to create a basic checkout configuration
+          return {
+            id: planId,
+            type: 'checkout_new_subscription',
+            embed: false,
+            success_url: `${window.location.origin}/family-plan-signup?success=true&plan_type=family`,
+            cancel_url: `${window.location.origin}/family-sign-up?cancelled=true`
+          };
+        },
+        success: (hostedPageId: string) => {
+          console.log('Checkout successful:', hostedPageId);
+          window.location.href =
+            '/family-plan-signup?success=true&plan_type=family&subscription=' +
+            encodeURIComponent(hostedPageId);
+        },
+        error: (error: any) => {
+          console.error('Checkout error:', error);
+          alert(
+            'There was an error processing your subscription. Please try again or contact support.'
+          );
+        },
+        close: () => {
+          console.log('Checkout closed by user');
+        }
+      });
+    } catch (error) {
+      console.error('Error opening Chargebee checkout:', error);
+
+      if (isDevelopment || isTestKey) {
+        alert(
+          'Chargebee configuration error in development. Using fallback simulation.'
+        );
+        const confirmed = window.confirm(
+          `Simulate subscription to Family Plan - ${billingCycle}?`
+        );
+        if (confirmed) {
+          window.location.href =
+            '/family-plan-signup?success=true&plan_type=family&billing=' +
+            encodeURIComponent(billingCycle);
+        }
+      } else {
+        alert('Unable to open checkout. Please contact support.');
+      }
+    }
+  };
+
+  return (
+    <>
+      <StructuredData
+        type='website'
+        pageTitle='Family Plan Sign Up — KOR'
+        pageDescription="Keep your whole family rolling with KOR's Family Plan. Track maintenance for up to 6 riders in one account."
+        url={`${baseUrl}/family-sign-up`}
+      />
+      <div className='parallax_parent'>
+        <div className='parallax_sign_up'>
+          <div style={{ padding: '5%' }}>
+            <h1 className='title_box'>Family Plan Sign Up</h1>
+            <div className='mobile_textbox'>
+              <p className='paragraph'>
+                Keep your whole family rolling! The KOR Family Plan is perfect
+                for families, roommates, or small groups who want to track bike
+                maintenance together. Manage up to 6 riders, track unlimited
+                bikes, and never miss a maintenance reminder again.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className='parallax_parent'>
+        <div className='parallax2_sign_up'>
+          <div style={{ padding: '5%', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+            <div style={{ maxWidth: '900px', width: '100%' }}>
+              <div className='payment-card1'>
+                <h1>Family Plan</h1>
+                <h2 className='title'>$X/month</h2>
+                <h2 className='title'>Features</h2>
+                <ul className='list'>
+                  <li>Up to 6 family members/riders</li>
+                  <li>Unlimited bikes per family</li>
+                  <li>Comprehensive maintenance tracking</li>
+                  <li>Automated wear notifications for all members</li>
+                  <li>Shared maintenance history</li>
+                  <li>QR code for easy member onboarding</li>
+                  <li>Family dashboard with all bikes at a glance</li>
+                  <li>Email support</li>
+                </ul>
+              </div>
+              <div className='payment1'>
+                <div className='payment-row' style={{ display: 'flex', gap: '1rem', justifyContent: 'center', flexWrap: 'wrap' }}>
+                  <button
+                    type='button'
+                    className='subscribe'
+                    onClick={() => handleSubscription('Monthly')}
+                  >
+                    Subscribe Monthly - $X/mo
+                  </button>
+                  <button
+                    type='button'
+                    className='subscribe'
+                    onClick={() => handleSubscription('Yearly')}
+                  >
+                    Subscribe Yearly $X
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default FamilyPlanPricing;

--- a/kor-react/src/components/pages/FamilyPlanSignUp.tsx
+++ b/kor-react/src/components/pages/FamilyPlanSignUp.tsx
@@ -1,0 +1,681 @@
+import React, { useState, useEffect } from 'react';
+import { useAuth0 } from '@auth0/auth0-react';
+import {
+  useLegacyParams,
+  buildLegacyUrl,
+  logLegacyParams
+} from '../../hooks/useLegacyParams';
+
+interface FormData {
+  family_name: string;
+  email: string;
+  password: string;
+  phone: string;
+  family_initials: string;
+}
+
+const FamilyPlanSignUp: React.FC = () => {
+  const { loginWithRedirect } = useAuth0();
+  const params = useLegacyParams();
+
+  const [formData, setFormData] = useState<FormData>({
+    family_name: '',
+    email: '',
+    password: '',
+    phone: '',
+    family_initials: ''
+  });
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string>('');
+  const [showPassword, setShowPassword] = useState(false);
+
+  useEffect(() => {
+    logLegacyParams(params, 'FamilySignIn');
+  }, [params]);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({
+      ...prev,
+      [name]: value
+    }));
+  };
+
+  const validateEmail = (email: string): boolean => {
+    const re = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return re.test(email);
+  };
+
+  const validatePhone = (phone: string): boolean => {
+    const re = /^[+]?[1-9]?[0-9]{7,15}$/;
+    return re.test(phone.replace(/[\s\-()]/g, ''));
+  };
+
+  // Legacy-compatible helpers based on the original site scripts
+  const getAuth0ManagementToken = async (): Promise<string> => {
+    const baseUrl =
+      process.env.REACT_APP_API_BASE_URL || 'https://jmrcycling.com:3001';
+    console.log('🪪 [FamilyPlanSignUp][Token] Requesting management token', {
+      endpoint: `${baseUrl}/getauth0Token`
+    });
+    const resp = await fetch(`${baseUrl}/getauth0Token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        access_token: 'auth0_token'
+      }) as unknown as BodyInit,
+      redirect: 'follow' as RequestRedirect
+    });
+    console.log('🪪 [FamilyPlanSignUp][Token] Response received', {
+      status: resp.status
+    });
+
+    if (!resp.ok) {
+      let errTxt = '';
+      try {
+        errTxt = await resp.text();
+      } catch {}
+      console.warn(
+        '🪪 [FamilyPlanSignUp][Token] Non-OK response body',
+        errTxt?.slice(0, 200)
+      );
+      throw new Error(`Failed to get Auth0 token (${resp.status})`);
+    }
+
+    // Some legacy endpoints return text that needs parsing
+    let data: any;
+    try {
+      data = await resp.json();
+    } catch {
+      const text = await resp.text();
+      data = JSON.parse(text);
+    }
+
+    const token = data?.token?.[0]?.auth0_token;
+    console.log('🪪 [FamilyPlanSignUp][Token] Token parsed', {
+      length: token ? String(token).length : 0
+    });
+    if (!token) throw new Error('Auth0 token missing in response');
+    return token;
+  };
+
+  const createAuth0User = async (
+    email: string,
+    password: string,
+    name: string,
+    mgmtToken: string
+  ): Promise<string> => {
+    const domain =
+      process.env.REACT_APP_AUTH0_DOMAIN || 'dev-oseu3r74.us.auth0.com';
+    const url = `https://${domain}/api/v2/users`;
+    console.log('👤 [FamilyPlanSignUp][Auth0User] Creating Auth0 user', {
+      domain,
+      url
+    });
+
+    // Create user with the password they provided in the form (they'll also log in via Auth0 Universal Login)
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${mgmtToken}`
+      },
+      body: JSON.stringify({
+        email,
+        password,
+        connection: 'Username-Password-Authentication',
+        name
+      }),
+      redirect: 'follow' as RequestRedirect
+    });
+
+    // Auth0 Management API often returns JSON with user_id or error payload
+    const payloadText = await resp.text();
+    let payload: any = {};
+    try {
+      payload = JSON.parse(payloadText);
+    } catch {
+      /* leave as text for diagnostics */
+    }
+    console.log('👤 [FamilyPlanSignUp][Auth0User] Response', {
+      status: resp.status,
+      hasUserId: !!payload?.user_id,
+      hasError: !!payload?.error
+    });
+
+    if (!resp.ok || payload?.error) {
+      // Check if user already exists
+      if (resp.status === 400 && (payload?.message?.includes('user already exists') || payload?.error === 'Conflict')) {
+        console.warn('👤 [FamilyPlanSignUp][Auth0User] User already exists, this may be from a previous signup attempt');
+        // Don't throw - let backend handle existing user
+        // Return a placeholder that will be replaced by backend lookup
+        return 'existing-user';
+      }
+      
+      const message =
+        payload?.message ||
+        payload?.error_description ||
+        payload?.error ||
+        `Failed to create Auth0 user (${resp.status})`;
+      console.error('👤 [FamilyPlanSignUp][Auth0User] Error creating user', {
+        status: resp.status,
+        message,
+        payloadSnippet:
+          typeof payloadText === 'string'
+            ? payloadText.slice(0, 200)
+            : undefined
+      });
+      throw new Error(message);
+    }
+
+    if (!payload?.user_id) {
+      console.error('👤 [FamilyPlanSignUp][Auth0User] No user_id in response', payload);
+      throw new Error('Auth0 user created but no user_id returned');
+    }
+
+    return payload.user_id as string;
+  };
+
+  const createFamilyAccount = async (userId: string): Promise<void> => {
+    const baseUrl =
+      process.env.REACT_APP_API_BASE_URL || 'https://jmrcycling.com:3001';
+    const bearer = process.env.REACT_APP_API_AUTH_TOKEN;
+    const isDevelopment = process.env.NODE_ENV === 'development' || process.env.REACT_APP_ENVIRONMENT === 'development';
+
+    const paramsBody = new URLSearchParams();
+    paramsBody.append('shop_name', formData.family_name); // Backend uses shop_name field
+    paramsBody.append('email', formData.email);
+    
+    // Always generate subscription IDs if not provided (family plans may not have real sub IDs)
+    const subId = params.sub_id || 'family_sub_' + Date.now();
+    const invoiceId = params.invoice_id || 'family_invoice_' + Date.now();
+    
+    paramsBody.append('sub_Id', subId);
+    paramsBody.append('invoice_Id', invoiceId);
+    
+    // CRITICAL: Always set to family - this is the family signup flow
+    paramsBody.append('plan_type', 'family');
+    
+    paramsBody.append('phone', formData.phone);
+    
+    // If userId is 'existing-user' from duplicate Auth0 user, backend should lookup by email
+    if (userId !== 'existing-user') {
+      paramsBody.append('user_id', userId);
+    }
+    
+    paramsBody.append('shop_init', formData.family_initials); // Backend uses shop_init field
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/x-www-form-urlencoded'
+    };
+    if (bearer) headers['Authorization'] = `Bearer ${bearer}`;
+
+    console.log('👨‍👩‍👧‍👦 [FamilyPlanSignUp][Backend] Creating family account', {
+      endpoint: `${baseUrl}/signinShop`,
+      hasBearer: !!bearer,
+      bodyKeys: Array.from(paramsBody.keys()),
+      planType: paramsBody.get('plan_type'),
+      userId: userId === 'existing-user' ? 'existing-user (will lookup by email)' : userId,
+      email: formData.email
+    });
+
+    const resp = await fetch(`${baseUrl}/signinShop`, {
+      method: 'POST',
+      headers,
+      body: paramsBody as unknown as BodyInit,
+      redirect: 'follow' as RequestRedirect
+    });
+
+    const respText = await resp.text();
+    let respData: any = {};
+    try {
+      respData = JSON.parse(respText);
+    } catch {
+      // Response might not be JSON
+    }
+    
+    console.log('👨‍👩‍👧‍👦 [FamilyPlanSignUp][Backend] Response', {
+      status: resp.status,
+      bodySnippet: respText.slice(0, 200),
+      parsedData: respData,
+      planTypeInResponse: respData?.plan_type || 'not found'
+    });
+
+    if (!resp.ok) {
+      throw new Error(
+        `Failed to create family account (${resp.status}) ${respText || ''}`
+      );
+    }
+    
+    // Verify plan_type was set correctly
+    if (respData?.plan_type && respData.plan_type !== 'family') {
+      console.warn('⚠️ [FamilyPlanSignUp][Backend] Plan type mismatch! Expected family, got:', respData.plan_type);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+
+    // Validate form
+    if (!formData.family_name.trim()) {
+      setError('Please enter your family name');
+      return;
+    }
+
+    if (!validateEmail(formData.email)) {
+      setError('Please enter a valid email address');
+      return;
+    }
+
+    if (formData.password.length < 8) {
+      setError('Password must be at least 8 characters long');
+      return;
+    }
+
+    if (!validatePhone(formData.phone)) {
+      setError('Please enter a valid phone number');
+      return;
+    }
+
+    if (!formData.family_initials.trim()) {
+      setError('Please enter family initials');
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const traceId = Math.random().toString(36).slice(2, 8);
+      console.log(
+        `🚀 [FamilyPlanSignUp][Trace ${traceId}] Starting family signup flow`,
+        {
+          formData: { ...formData, password: '[REDACTED]' },
+          params,
+          timestamp: new Date().toISOString()
+        }
+      );
+
+      // 1) Get Auth0 management token from backend
+      const mgmtToken = await getAuth0ManagementToken();
+      console.log('🪪 [FamilyPlanSignUp] Management token acquired');
+
+      // 2) Create Auth0 user account with provided password
+      const auth0UserId = await createAuth0User(
+        formData.email,
+        formData.password,
+        formData.family_name,
+        mgmtToken
+      );
+      console.log('👤 [FamilyPlanSignUp] Auth0 user created', {
+        userId: auth0UserId
+      });
+
+      // 3) Create KOR family account in backend (binds Auth0 user to family)
+      await createFamilyAccount(auth0UserId);
+      console.log('👨‍👩‍👧‍👦 [FamilyPlanSignUp] Family account created on server');
+
+      // 4) Redirect to Auth0 login; user will log in using the password just created
+      const redirectUri = window.location.origin + '/shop/login';
+      console.log('🔐 [FamilyPlanSignUp] Redirecting to Auth0 login', {
+        redirectUri
+      });
+      await loginWithRedirect({
+        authorizationParams: {
+          redirect_uri: redirectUri,
+          login_hint: formData.email
+        }
+      });
+    } catch (err: any) {
+      console.error('❌ [FamilyPlanSignUp] Signup flow error', {
+        message: err?.message,
+        stack: err?.stack
+      });
+      const message =
+        typeof err?.message === 'string' && err.message
+          ? err.message
+          : 'An error occurred during account creation. Please try again.';
+      setError(message);
+    } finally {
+      console.log('🏁 [FamilyPlanSignUp] Flow complete');
+      setIsLoading(false);
+    }
+  };
+
+  const handleAuthWithAuth0 = async () => {
+    try {
+      // Build return URL with current parameters
+      const returnUrl = buildLegacyUrl('/shop/dashboard', {
+        ...params,
+        plan_type: 'family'
+      });
+      console.log('🔐 [FamilyPlanSignUp] Manual Auth0 login requested', {
+        returnUrl
+      });
+
+      await loginWithRedirect({
+        authorizationParams: {
+          redirect_uri: window.location.origin + returnUrl
+        }
+      });
+    } catch (error) {
+      console.error('🔐 [FamilyPlanSignUp] Auth0 login error:', error);
+      setError('Authentication failed. Please try again.');
+    }
+  };
+
+  const signInContent = (
+    <div
+      className='page-container'
+      style={{ maxWidth: '600px', margin: '2rem auto', padding: '2rem' }}
+    >
+      <div
+        style={{
+          backgroundColor: 'white',
+          padding: '2rem',
+          borderRadius: '8px',
+          boxShadow: '0 2px 10px rgba(0,0,0,0.1)'
+        }}
+      >
+        <div style={{ textAlign: 'center', marginBottom: '2rem' }}>
+          <img
+            src='/images/KOR_app_Logo.png'
+            alt='KOR Logo'
+            style={{ width: '80px', height: '80px', marginBottom: '1rem' }}
+          />
+          <h1 style={{ color: '#BF4A00', marginBottom: '0.5rem' }}>
+            Create Family Account
+          </h1>
+          <p style={{ color: '#666', marginBottom: '0' }}>
+            Set up your family plan and start tracking together
+          </p>
+        </div>
+
+        {error && (
+          <div
+            style={{
+              backgroundColor: '#ffe6e6',
+              color: '#d63031',
+              padding: '1rem',
+              borderRadius: '4px',
+              marginBottom: '1rem',
+              border: '1px solid #d63031'
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        {/* Display current parameters for debugging */}
+        {process.env.NODE_ENV === 'development' && (
+          <div
+            style={{
+              backgroundColor: '#f8f9fa',
+              padding: '1rem',
+              borderRadius: '4px',
+              marginBottom: '1rem',
+              fontSize: '0.8rem'
+            }}
+          >
+            <strong>Debug - Legacy Parameters:</strong>
+            <br />
+            Sub ID: {params.sub_id || 'None'}
+            <br />
+            Invoice ID: {params.invoice_id || 'None'}
+            <br />
+            Plan Type: {params.plan_type || 'family (default)'}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit}>
+          <div style={{ display: 'grid', gap: '1rem' }}>
+            <div>
+              <label
+                htmlFor='family_name'
+                style={{
+                  display: 'block',
+                  marginBottom: '0.5rem',
+                  fontWeight: 'bold'
+                }}
+              >
+                Family Name
+              </label>
+              <input
+                type='text'
+                id='family_name'
+                name='family_name'
+                value={formData.family_name}
+                onChange={handleInputChange}
+                placeholder=''
+                required
+                style={{
+                  width: '100%',
+                  padding: '0.75rem',
+                  border: '1px solid #ddd',
+                  borderRadius: '4px',
+                  fontSize: '1rem'
+                }}
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor='email'
+                style={{
+                  display: 'block',
+                  marginBottom: '0.5rem',
+                  fontWeight: 'bold'
+                }}
+              >
+                Email Address
+              </label>
+              <input
+                type='email'
+                id='email'
+                name='email'
+                value={formData.email}
+                onChange={handleInputChange}
+                placeholder=''
+                required
+                style={{
+                  width: '100%',
+                  padding: '0.75rem',
+                  border: '1px solid #ddd',
+                  borderRadius: '4px',
+                  fontSize: '1rem'
+                }}
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor='password'
+                style={{
+                  display: 'block',
+                  marginBottom: '0.5rem',
+                  fontWeight: 'bold'
+                }}
+              >
+                Password
+              </label>
+              <div
+                style={{
+                  position: 'relative',
+                  display: 'flex',
+                  alignItems: 'center'
+                }}
+              >
+                <input
+                  type={showPassword ? 'text' : 'password'}
+                  id='password'
+                  name='password'
+                  value={formData.password}
+                  onChange={handleInputChange}
+                  placeholder=''
+                  required
+                  minLength={8}
+                  style={{
+                    width: '100%',
+                    padding: '0.75rem',
+                    border: '1px solid #ddd',
+                    borderRadius: '4px',
+                    fontSize: '1rem'
+                  }}
+                />
+                <button
+                  type='button'
+                  onClick={() => setShowPassword(!showPassword)}
+                  style={{
+                    position: 'absolute',
+                    right: '0.75rem',
+                    background: 'none',
+                    border: 'none',
+                    cursor: 'pointer',
+                    color: '#BF4A00',
+                    fontSize: '0.85rem',
+                    padding: '0.25rem',
+                    fontWeight: '500'
+                  }}
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
+                >
+                  {showPassword ? 'Hide' : 'Show'}
+                </button>
+              </div>
+              <small
+                style={{
+                  color: '#666',
+                  fontSize: '0.85rem',
+                  display: 'block',
+                  marginTop: '0.25rem'
+                }}
+              >
+                You will confirm this on the next page
+              </small>
+            </div>
+
+            <div>
+              <label
+                htmlFor='phone'
+                style={{
+                  display: 'block',
+                  marginBottom: '0.5rem',
+                  fontWeight: 'bold'
+                }}
+              >
+                Phone Number
+              </label>
+              <input
+                type='tel'
+                id='phone'
+                name='phone'
+                value={formData.phone}
+                onChange={handleInputChange}
+                placeholder=''
+                required
+                style={{
+                  width: '100%',
+                  padding: '0.75rem',
+                  border: '1px solid #ddd',
+                  borderRadius: '4px',
+                  fontSize: '1rem'
+                }}
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor='family_initials'
+                style={{
+                  display: 'block',
+                  marginBottom: '0.5rem',
+                  fontWeight: 'bold'
+                }}
+              >
+                Family Initials
+              </label>
+              <input
+                type='text'
+                id='family_initials'
+                name='family_initials'
+                value={formData.family_initials}
+                onChange={handleInputChange}
+                placeholder=''
+                required
+                maxLength={4}
+                style={{
+                  width: '100%',
+                  padding: '0.75rem',
+                  border: '1px solid #ddd',
+                  borderRadius: '4px',
+                  fontSize: '1rem'
+                }}
+              />
+              <small style={{ color: '#666', fontSize: '0.8rem' }}>
+                2-4 characters (e.g., "SM" for Smith Family)
+              </small>
+            </div>
+          </div>
+
+          <div
+            style={{
+              marginTop: '2rem',
+              display: 'flex',
+              gap: '1rem',
+              flexDirection: 'column'
+            }}
+          >
+            <button
+              type='submit'
+              disabled={isLoading}
+              style={{
+                backgroundColor: isLoading ? '#ccc' : '#BF4A00',
+                color: 'white',
+                border: 'none',
+                padding: '1rem',
+                borderRadius: '4px',
+                fontSize: '1rem',
+                cursor: isLoading ? 'not-allowed' : 'pointer'
+              }}
+            >
+              {isLoading ? 'Creating Account...' : 'Create Family Account'}
+            </button>
+
+            <div style={{ textAlign: 'center', margin: '1rem 0' }}>
+              <span style={{ color: '#666' }}>- OR -</span>
+            </div>
+
+            <button
+              type='button'
+              onClick={handleAuthWithAuth0}
+              style={{
+                backgroundColor: '#28a745',
+                color: 'white',
+                border: 'none',
+                padding: '1rem',
+                borderRadius: '4px',
+                fontSize: '1rem',
+                cursor: 'pointer'
+              }}
+            >
+              Sign in with Auth0
+            </button>
+          </div>
+
+          <div style={{ textAlign: 'center', marginTop: '1rem' }}>
+            <p style={{ color: '#666' }}>
+              Already have an account?{' '}
+              <a href='/shop/login' style={{ color: '#BF4A00' }}>
+                Sign In
+              </a>
+            </p>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+
+  return signInContent;
+};
+
+export default FamilyPlanSignUp;

--- a/kor-react/src/components/pages/FamilyPlanSignUp.tsx
+++ b/kor-react/src/components/pages/FamilyPlanSignUp.tsx
@@ -1,0 +1,643 @@
+import React, { useState, useEffect } from 'react';
+import { useAuth0 } from '@auth0/auth0-react';
+import {
+  useLegacyParams,
+  buildLegacyUrl,
+  logLegacyParams
+} from '../../hooks/useLegacyParams';
+
+interface FormData {
+  family_name: string;
+  email: string;
+  password: string;
+  phone: string;
+  family_initials: string;
+}
+
+const FamilyPlanSignUp: React.FC = () => {
+  const { loginWithRedirect } = useAuth0();
+  const params = useLegacyParams();
+
+  const [formData, setFormData] = useState<FormData>({
+    family_name: '',
+    email: '',
+    password: '',
+    phone: '',
+    family_initials: ''
+  });
+
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string>('');
+  const [showPassword, setShowPassword] = useState(false);
+
+  useEffect(() => {
+    logLegacyParams(params, 'FamilySignIn');
+  }, [params]);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({
+      ...prev,
+      [name]: value
+    }));
+  };
+
+  const validateEmail = (email: string): boolean => {
+    const re = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    return re.test(email);
+  };
+
+  const validatePhone = (phone: string): boolean => {
+    const re = /^[+]?[1-9]?[0-9]{7,15}$/;
+    return re.test(phone.replace(/[\s\-()]/g, ''));
+  };
+
+  // Legacy-compatible helpers based on the original site scripts
+  const getAuth0ManagementToken = async (): Promise<string> => {
+    const baseUrl =
+      process.env.REACT_APP_API_BASE_URL || 'https://jmrcycling.com:3001';
+    console.log('🪪 [FamilyPlanSignUp][Token] Requesting management token', {
+      endpoint: `${baseUrl}/getauth0Token`
+    });
+    const resp = await fetch(`${baseUrl}/getauth0Token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        access_token: 'auth0_token'
+      }) as unknown as BodyInit,
+      redirect: 'follow' as RequestRedirect
+    });
+    console.log('🪪 [FamilyPlanSignUp][Token] Response received', {
+      status: resp.status
+    });
+
+    if (!resp.ok) {
+      let errTxt = '';
+      try {
+        errTxt = await resp.text();
+      } catch {}
+      console.warn(
+        '🪪 [FamilyPlanSignUp][Token] Non-OK response body',
+        errTxt?.slice(0, 200)
+      );
+      throw new Error(`Failed to get Auth0 token (${resp.status})`);
+    }
+
+    // Some legacy endpoints return text that needs parsing
+    let data: any;
+    try {
+      data = await resp.json();
+    } catch {
+      const text = await resp.text();
+      data = JSON.parse(text);
+    }
+
+    const token = data?.token?.[0]?.auth0_token;
+    console.log('🪪 [FamilyPlanSignUp][Token] Token parsed', {
+      length: token ? String(token).length : 0
+    });
+    if (!token) throw new Error('Auth0 token missing in response');
+    return token;
+  };
+
+  const createAuth0User = async (
+    email: string,
+    password: string,
+    name: string,
+    mgmtToken: string
+  ): Promise<string> => {
+    const domain =
+      process.env.REACT_APP_AUTH0_DOMAIN || 'dev-oseu3r74.us.auth0.com';
+    const url = `https://${domain}/api/v2/users`;
+    console.log('👤 [FamilyPlanSignUp][Auth0User] Creating Auth0 user', {
+      domain,
+      url
+    });
+
+    // Create user with the password they provided in the form (they'll also log in via Auth0 Universal Login)
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${mgmtToken}`
+      },
+      body: JSON.stringify({
+        email,
+        password,
+        connection: 'Username-Password-Authentication',
+        name
+      }),
+      redirect: 'follow' as RequestRedirect
+    });
+
+    // Auth0 Management API often returns JSON with user_id or error payload
+    const payloadText = await resp.text();
+    let payload: any = {};
+    try {
+      payload = JSON.parse(payloadText);
+    } catch {
+      /* leave as text for diagnostics */
+    }
+    console.log('👤 [FamilyPlanSignUp][Auth0User] Response', {
+      status: resp.status,
+      hasUserId: !!payload?.user_id,
+      hasError: !!payload?.error
+    });
+
+    if (!resp.ok || payload?.error || !payload?.user_id) {
+      const message =
+        payload?.message ||
+        payload?.error_description ||
+        payload?.error ||
+        `Failed to create Auth0 user (${resp.status})`;
+      console.error('👤 [FamilyPlanSignUp][Auth0User] Error creating user', {
+        status: resp.status,
+        message,
+        payloadSnippet:
+          typeof payloadText === 'string'
+            ? payloadText.slice(0, 200)
+            : undefined
+      });
+      throw new Error(message);
+    }
+
+    return payload.user_id as string;
+  };
+
+  const createFamilyAccount = async (userId: string): Promise<void> => {
+    const baseUrl =
+      process.env.REACT_APP_API_BASE_URL || 'https://jmrcycling.com:3001';
+    const bearer = process.env.REACT_APP_API_AUTH_TOKEN;
+    const isDevelopment = process.env.NODE_ENV === 'development' || process.env.REACT_APP_ENVIRONMENT === 'development';
+
+    const paramsBody = new URLSearchParams();
+    paramsBody.append('shop_name', formData.family_name); // Backend uses shop_name field
+    paramsBody.append('email', formData.email);
+    
+    // In dev mode, use dummy subscription IDs if not provided
+    const subId = params.sub_id || (isDevelopment ? 'dev_family_sub_' + Date.now() : null);
+    const invoiceId = params.invoice_id || (isDevelopment ? 'dev_family_invoice_' + Date.now() : null);
+    
+    if (subId) paramsBody.append('sub_Id', subId);
+    if (invoiceId) paramsBody.append('invoice_Id', invoiceId);
+    paramsBody.append('plan_type', 'family'); // Always set to family
+    paramsBody.append('phone', formData.phone);
+    paramsBody.append('user_id', userId);
+    paramsBody.append('shop_init', formData.family_initials); // Backend uses shop_init field
+
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/x-www-form-urlencoded'
+    };
+    if (bearer) headers['Authorization'] = `Bearer ${bearer}`;
+
+    console.log('👨‍👩‍👧‍👦 [FamilyPlanSignUp][Backend] Creating family account', {
+      endpoint: `${baseUrl}/signinShop`,
+      hasBearer: !!bearer,
+      bodyKeys: Array.from(paramsBody.keys())
+    });
+
+    const resp = await fetch(`${baseUrl}/signinShop`, {
+      method: 'POST',
+      headers,
+      body: paramsBody as unknown as BodyInit,
+      redirect: 'follow' as RequestRedirect
+    });
+
+    const respText = await resp.text();
+    console.log('👨‍👩‍👧‍👦 [FamilyPlanSignUp][Backend] Response', {
+      status: resp.status,
+      bodySnippet: respText.slice(0, 200)
+    });
+
+    if (!resp.ok) {
+      throw new Error(
+        `Failed to create family account (${resp.status}) ${respText || ''}`
+      );
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+
+    // Validate form
+    if (!formData.family_name.trim()) {
+      setError('Please enter your family name');
+      return;
+    }
+
+    if (!validateEmail(formData.email)) {
+      setError('Please enter a valid email address');
+      return;
+    }
+
+    if (formData.password.length < 8) {
+      setError('Password must be at least 8 characters long');
+      return;
+    }
+
+    if (!validatePhone(formData.phone)) {
+      setError('Please enter a valid phone number');
+      return;
+    }
+
+    if (!formData.family_initials.trim()) {
+      setError('Please enter family initials');
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const traceId = Math.random().toString(36).slice(2, 8);
+      console.log(
+        `🚀 [FamilyPlanSignUp][Trace ${traceId}] Starting family signup flow`,
+        {
+          formData: { ...formData, password: '[REDACTED]' },
+          params,
+          timestamp: new Date().toISOString()
+        }
+      );
+
+      // 1) Get Auth0 management token from backend
+      const mgmtToken = await getAuth0ManagementToken();
+      console.log('🪪 [FamilyPlanSignUp] Management token acquired');
+
+      // 2) Create Auth0 user account with provided password
+      const auth0UserId = await createAuth0User(
+        formData.email,
+        formData.password,
+        formData.family_name,
+        mgmtToken
+      );
+      console.log('👤 [FamilyPlanSignUp] Auth0 user created', {
+        userId: auth0UserId
+      });
+
+      // 3) Create KOR family account in backend (binds Auth0 user to family)
+      await createFamilyAccount(auth0UserId);
+      console.log('👨‍👩‍👧‍👦 [FamilyPlanSignUp] Family account created on server');
+
+      // 4) Redirect to Auth0 login; user will log in using the password just created
+      const redirectUri = window.location.origin + '/shop/login';
+      console.log('🔐 [FamilyPlanSignUp] Redirecting to Auth0 login', {
+        redirectUri
+      });
+      await loginWithRedirect({
+        authorizationParams: {
+          redirect_uri: redirectUri,
+          login_hint: formData.email
+        }
+      });
+    } catch (err: any) {
+      console.error('❌ [FamilyPlanSignUp] Signup flow error', {
+        message: err?.message,
+        stack: err?.stack
+      });
+      const message =
+        typeof err?.message === 'string' && err.message
+          ? err.message
+          : 'An error occurred during account creation. Please try again.';
+      setError(message);
+    } finally {
+      console.log('🏁 [FamilyPlanSignUp] Flow complete');
+      setIsLoading(false);
+    }
+  };
+
+  const handleAuthWithAuth0 = async () => {
+    try {
+      // Build return URL with current parameters
+      const returnUrl = buildLegacyUrl('/shop/dashboard', {
+        ...params,
+        plan_type: 'family'
+      });
+      console.log('🔐 [FamilyPlanSignUp] Manual Auth0 login requested', {
+        returnUrl
+      });
+
+      await loginWithRedirect({
+        authorizationParams: {
+          redirect_uri: window.location.origin + returnUrl
+        }
+      });
+    } catch (error) {
+      console.error('🔐 [FamilyPlanSignUp] Auth0 login error:', error);
+      setError('Authentication failed. Please try again.');
+    }
+  };
+
+  const signInContent = (
+    <div
+      className='page-container'
+      style={{ maxWidth: '600px', margin: '2rem auto', padding: '2rem' }}
+    >
+      <div
+        style={{
+          backgroundColor: 'white',
+          padding: '2rem',
+          borderRadius: '8px',
+          boxShadow: '0 2px 10px rgba(0,0,0,0.1)'
+        }}
+      >
+        <div style={{ textAlign: 'center', marginBottom: '2rem' }}>
+          <img
+            src='/images/KOR_app_Logo.png'
+            alt='KOR Logo'
+            style={{ width: '80px', height: '80px', marginBottom: '1rem' }}
+          />
+          <h1 style={{ color: '#BF4A00', marginBottom: '0.5rem' }}>
+            Create Family Account
+          </h1>
+          <p style={{ color: '#666', marginBottom: '0' }}>
+            Set up your family plan and start tracking together
+          </p>
+        </div>
+
+        {error && (
+          <div
+            style={{
+              backgroundColor: '#ffe6e6',
+              color: '#d63031',
+              padding: '1rem',
+              borderRadius: '4px',
+              marginBottom: '1rem',
+              border: '1px solid #d63031'
+            }}
+          >
+            {error}
+          </div>
+        )}
+
+        {/* Display current parameters for debugging */}
+        {process.env.NODE_ENV === 'development' && (
+          <div
+            style={{
+              backgroundColor: '#f8f9fa',
+              padding: '1rem',
+              borderRadius: '4px',
+              marginBottom: '1rem',
+              fontSize: '0.8rem'
+            }}
+          >
+            <strong>Debug - Legacy Parameters:</strong>
+            <br />
+            Sub ID: {params.sub_id || 'None'}
+            <br />
+            Invoice ID: {params.invoice_id || 'None'}
+            <br />
+            Plan Type: {params.plan_type || 'family (default)'}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit}>
+          <div style={{ display: 'grid', gap: '1rem' }}>
+            <div>
+              <label
+                htmlFor='family_name'
+                style={{
+                  display: 'block',
+                  marginBottom: '0.5rem',
+                  fontWeight: 'bold'
+                }}
+              >
+                Family Name
+              </label>
+              <input
+                type='text'
+                id='family_name'
+                name='family_name'
+                value={formData.family_name}
+                onChange={handleInputChange}
+                placeholder=''
+                required
+                style={{
+                  width: '100%',
+                  padding: '0.75rem',
+                  border: '1px solid #ddd',
+                  borderRadius: '4px',
+                  fontSize: '1rem'
+                }}
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor='email'
+                style={{
+                  display: 'block',
+                  marginBottom: '0.5rem',
+                  fontWeight: 'bold'
+                }}
+              >
+                Email Address
+              </label>
+              <input
+                type='email'
+                id='email'
+                name='email'
+                value={formData.email}
+                onChange={handleInputChange}
+                placeholder=''
+                required
+                style={{
+                  width: '100%',
+                  padding: '0.75rem',
+                  border: '1px solid #ddd',
+                  borderRadius: '4px',
+                  fontSize: '1rem'
+                }}
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor='password'
+                style={{
+                  display: 'block',
+                  marginBottom: '0.5rem',
+                  fontWeight: 'bold'
+                }}
+              >
+                Password
+              </label>
+              <div
+                style={{
+                  position: 'relative',
+                  display: 'flex',
+                  alignItems: 'center'
+                }}
+              >
+                <input
+                  type={showPassword ? 'text' : 'password'}
+                  id='password'
+                  name='password'
+                  value={formData.password}
+                  onChange={handleInputChange}
+                  placeholder=''
+                  required
+                  minLength={8}
+                  style={{
+                    width: '100%',
+                    padding: '0.75rem',
+                    border: '1px solid #ddd',
+                    borderRadius: '4px',
+                    fontSize: '1rem'
+                  }}
+                />
+                <button
+                  type='button'
+                  onClick={() => setShowPassword(!showPassword)}
+                  style={{
+                    position: 'absolute',
+                    right: '0.75rem',
+                    background: 'none',
+                    border: 'none',
+                    cursor: 'pointer',
+                    color: '#BF4A00',
+                    fontSize: '0.85rem',
+                    padding: '0.25rem',
+                    fontWeight: '500'
+                  }}
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
+                >
+                  {showPassword ? 'Hide' : 'Show'}
+                </button>
+              </div>
+              <small
+                style={{
+                  color: '#666',
+                  fontSize: '0.85rem',
+                  display: 'block',
+                  marginTop: '0.25rem'
+                }}
+              >
+                You will confirm this on the next page
+              </small>
+            </div>
+
+            <div>
+              <label
+                htmlFor='phone'
+                style={{
+                  display: 'block',
+                  marginBottom: '0.5rem',
+                  fontWeight: 'bold'
+                }}
+              >
+                Phone Number
+              </label>
+              <input
+                type='tel'
+                id='phone'
+                name='phone'
+                value={formData.phone}
+                onChange={handleInputChange}
+                placeholder=''
+                required
+                style={{
+                  width: '100%',
+                  padding: '0.75rem',
+                  border: '1px solid #ddd',
+                  borderRadius: '4px',
+                  fontSize: '1rem'
+                }}
+              />
+            </div>
+
+            <div>
+              <label
+                htmlFor='family_initials'
+                style={{
+                  display: 'block',
+                  marginBottom: '0.5rem',
+                  fontWeight: 'bold'
+                }}
+              >
+                Family Initials
+              </label>
+              <input
+                type='text'
+                id='family_initials'
+                name='family_initials'
+                value={formData.family_initials}
+                onChange={handleInputChange}
+                placeholder=''
+                required
+                maxLength={4}
+                style={{
+                  width: '100%',
+                  padding: '0.75rem',
+                  border: '1px solid #ddd',
+                  borderRadius: '4px',
+                  fontSize: '1rem'
+                }}
+              />
+              <small style={{ color: '#666', fontSize: '0.8rem' }}>
+                2-4 characters (e.g., "SM" for Smith Family)
+              </small>
+            </div>
+          </div>
+
+          <div
+            style={{
+              marginTop: '2rem',
+              display: 'flex',
+              gap: '1rem',
+              flexDirection: 'column'
+            }}
+          >
+            <button
+              type='submit'
+              disabled={isLoading}
+              style={{
+                backgroundColor: isLoading ? '#ccc' : '#BF4A00',
+                color: 'white',
+                border: 'none',
+                padding: '1rem',
+                borderRadius: '4px',
+                fontSize: '1rem',
+                cursor: isLoading ? 'not-allowed' : 'pointer'
+              }}
+            >
+              {isLoading ? 'Creating Account...' : 'Create Family Account'}
+            </button>
+
+            <div style={{ textAlign: 'center', margin: '1rem 0' }}>
+              <span style={{ color: '#666' }}>- OR -</span>
+            </div>
+
+            <button
+              type='button'
+              onClick={handleAuthWithAuth0}
+              style={{
+                backgroundColor: '#28a745',
+                color: 'white',
+                border: 'none',
+                padding: '1rem',
+                borderRadius: '4px',
+                fontSize: '1rem',
+                cursor: 'pointer'
+              }}
+            >
+              Sign in with Auth0
+            </button>
+          </div>
+
+          <div style={{ textAlign: 'center', marginTop: '1rem' }}>
+            <p style={{ color: '#666' }}>
+              Already have an account?{' '}
+              <a href='/shop/login' style={{ color: '#BF4A00' }}>
+                Sign In
+              </a>
+            </p>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+
+  return signInContent;
+};
+
+export default FamilyPlanSignUp;

--- a/kor-react/src/components/pages/PersonalPlans.tsx
+++ b/kor-react/src/components/pages/PersonalPlans.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import StructuredData from '../common/StructuredData';
 
 const PersonalPlans: React.FC = () => {
@@ -9,26 +9,51 @@ const PersonalPlans: React.FC = () => {
     setSelectedPlan(planType);
   };
 
+  // Ensure Chargebee's drop-in script binds to dynamically rendered React elements
+  useEffect(() => {
+    const cb: any = (window as any).Chargebee;
+    if (cb && typeof cb.registerAgain === 'function') {
+      try {
+        cb.registerAgain();
+      } catch (e) {
+        console.error('Chargebee.registerAgain failed', e);
+      }
+    }
+  }, []);
+
   const handleSubscribe = (planType: string) => {
     // For now, redirect to app stores for the free version
     // In the future, this could integrate with payment processing for premium personal plans
-    
-    const message = `You've selected the ${planType} plan. ` +
-      `${planType === 'free' 
-        ? 'Click OK to download the free version from your app store.' 
-        : 'Premium personal plans will be available soon. For now, enjoy the free version!'}`;
-    
+
+    const message =
+      `You've selected the ${planType} plan. ` +
+      `${
+        planType === 'free'
+          ? 'Click OK to download the free version from your app store.'
+          : 'Premium personal plans will be available soon. For now, enjoy the free version!'
+      }`;
+
     if (window.confirm(message)) {
       // Redirect to app stores
-      const userAgent = navigator.userAgent || navigator.vendor || (window as any).opera;
-      
+      const userAgent =
+        navigator.userAgent || navigator.vendor || (window as any).opera;
+
       if (/android/i.test(userAgent)) {
-        window.open('https://play.google.com/store/apps/details?id=com.robtuft.newKOR', '_blank');
+        window.open(
+          'https://play.google.com/store/apps/details?id=com.robtuft.newKOR',
+          '_blank'
+        );
       } else if (/iPad|iPhone|iPod/.test(userAgent)) {
-        window.open('https://apps.apple.com/us/app/kor-keep-on-rolling/id1599601993', '_blank');
+        window.open(
+          'https://apps.apple.com/us/app/kor-keep-on-rolling/id1599601993',
+          '_blank'
+        );
       } else {
         // Default to Google Play for desktop users
-        window.open('https://play.google.com/store/apps/details?id=com.robtuft.newKOR', '_blank');
+        window.open(
+          'https://play.google.com/store/apps/details?id=com.robtuft.newKOR',
+          '_blank'
+        );
       }
     }
   };
@@ -36,64 +61,67 @@ const PersonalPlans: React.FC = () => {
   return (
     <>
       <StructuredData
-        type="website"
-        pageTitle="Personal Account Plans — KOR"
-        pageDescription="Track your bike maintenance for free today. Premium plans coming soon with advanced features and notifications."
+        type='website'
+        pageTitle='Personal Account Plans — KOR'
+        pageDescription='Track your bike maintenance for free today. Premium plans coming soon with advanced features and notifications.'
         url={`${baseUrl}/personal-plans`}
       />
-      <div className="parallax_parent">
-        <div className="parallax_sign_up">
+      <div className='parallax_parent'>
+        <div className='parallax_sign_up'>
           <div style={{ padding: '5%' }}>
-            <h1 className="title_box">Personal Account Plans</h1>
-            <div className="mobile_textbox">
-              <p className="paragraph">
-                Perfect for individual cyclists who want to track their bike maintenance 
-                without a bike shop partnership. Get started with our free version or 
-                upgrade to premium features for enhanced tracking and notifications.
+            <h1 className='title_box'>Personal Account Plans</h1>
+            <div className='mobile_textbox'>
+              <p className='paragraph'>
+                Perfect for individual cyclists who want to track their bike
+                maintenance without a bike shop partnership. Get started with
+                our free version or upgrade to premium features for enhanced
+                tracking and notifications.
               </p>
             </div>
           </div>
         </div>
       </div>
-      
-      <div className="parallax_parent">
-        <div className="parallax2_sign_up">
+
+      <div className='parallax_parent'>
+        <div className='parallax2_sign_up'>
           <div style={{ padding: '5%' }}>
-            <div className="payment-plans">
+            <div className='payment-plans'>
               {/* Free Plan */}
-              <div className={`payment-card1 ${selectedPlan === 'free' ? 'selected' : ''}`}>
+              <div
+                className={`payment-card1 ${selectedPlan === 'free' ? 'selected' : ''}`}
+              >
                 <h1>Free</h1>
-                <h2 className="title">$0/month</h2>
-                <h2 className="title">Features</h2>
-                <ul className="list">
+                <h2 className='title'>$0/month</h2>
+                <h2 className='title'>Features</h2>
+                <ul className='list'>
                   <li>Basic component tracking</li>
                   <li>Strava integration</li>
                   <li>Manual maintenance logging</li>
                   <li>Basic wear percentage alerts</li>
                   <li>Single bike support</li>
                 </ul>
-                <div className="plan-limitations">
-                  <h3 className="limitation-title">Limitations:</h3>
-                  <ul className="limitation-list">
+                <div className='plan-limitations'>
+                  <h3 className='limitation-title'>Limitations:</h3>
+                  <ul className='limitation-list'>
                     <li>Limited to basic components</li>
                     <li>Manual notifications only</li>
                     <li>No advanced analytics</li>
                   </ul>
                 </div>
               </div>
-              
-              <div className="payment1">
-                <div className="payment-row">
+
+              <div className='payment1'>
+                <div className='payment-row'>
                   <button
-                    type="button"
+                    type='button'
                     className={`subscribe ${selectedPlan === 'free' ? 'selected' : ''}`}
                     onClick={() => handlePlanSelect('free')}
                   >
                     {selectedPlan === 'free' ? 'Selected' : 'Select Free Plan'}
                   </button>
                   <button
-                    type="button"
-                    className="subscribe primary"
+                    type='button'
+                    className='subscribe primary'
                     onClick={() => handleSubscribe('free')}
                   >
                     Download Free App
@@ -103,15 +131,15 @@ const PersonalPlans: React.FC = () => {
 
               {/* Premium Plan (Coming Soon) */}
               {/* Premium Plan (Coming Soon) */}
-              <a 
-                href="/premium-plan" 
-                className={`payment-card2 ${selectedPlan === 'premium' ? 'selected' : ''}`} 
+              <a
+                href='/premium-plan'
+                className={`payment-card2 ${selectedPlan === 'premium' ? 'selected' : ''}`}
                 style={{ opacity: 0.8 }}
               >
                 <h1>Premium</h1>
-                <h2 className="title">$9.99/month</h2>
-                <h2 className="title">Features</h2>
-                <ul className="list">
+                <h2 className='title'>$9.99/month</h2>
+                <h2 className='title'>Features</h2>
+                <ul className='list'>
                   <li>All Free features</li>
                   <li>Advanced component tracking</li>
                   <li>Automated email/push notifications</li>
@@ -121,113 +149,168 @@ const PersonalPlans: React.FC = () => {
                   <li>Weather-based adjustments</li>
                   <li>Component replacement reminders</li>
                 </ul>
-                <div className="coming-soon-badge">
+                <div className='coming-soon-badge'>
                   <span>Coming Soon!</span>
                 </div>
               </a>
 
-              
-              <div className="payment2" style={{ opacity: 0.8 }}>
-                <div className="payment-row">
-                  <button
-                    type="button"
-                    className="subscribe disabled"
-                    disabled
-                  >
+              <div className='payment2' style={{ opacity: 0.8 }}>
+                <div className='payment-row'>
+                  <button type='button' className='subscribe disabled' disabled>
                     Coming Soon
                   </button>
-                  <p className="coming-soon-text">
-                    Premium personal plans will be available in Q2 2024. 
-                    Join our free version now and get notified when premium launches!
+                  <p className='coming-soon-text'>
+                    Premium personal plans will be available in Q2 2024. Join
+                    our free version now and get notified when premium launches!
                   </p>
                 </div>
               </div>
 
-              {/* Family Plan (Future) */}
-              <a href="/family-plan" className="payment-card3" style={{ opacity: 0.5 }}>
+              {/* Family Plan */}
+              <a
+                href='/family-plan-pricing'
+                className={`payment-card3 ${selectedPlan === 'family' ? 'selected' : ''}`}
+                onClick={e => {
+                  e.preventDefault();
+                  setSelectedPlan('family');
+                  window.location.href = '/family-plan-pricing';
+                }}
+              >
                 <h1>Family</h1>
-                <h2 className="title">$19.99/month</h2>
-                <h2 className="title">Features</h2>
-                <ul className="list">
-                  <li>All Premium features</li>
-                  <li>Unlimited bikes</li>
-                  <li>Team/family sharing up to 6 total users</li>
-                  <li>Advanced part recommendations</li>
-                  <li>Integration with bike shop networks</li>
-                  <li>Priority customer support</li>
-                  <li>Custom component databases</li>
+                <h2 className='title'>$19.99/month</h2>
+                <h2 className='title'>Features</h2>
+                <ul className='list'>
+                  <li>Up to 6 family members/riders</li>
+                  <li>Unlimited bikes per family</li>
+                  <li>Comprehensive maintenance tracking</li>
+                  <li>Automated wear notifications for all members</li>
+                  <li>Shared maintenance history</li>
+                  <li>QR code for easy member onboarding</li>
+                  <li>Family dashboard with all bikes at a glance</li>
+                  <li>Email support</li>
                 </ul>
-                <h1 style={{ bottom: '30%', opacity: 1 }}>
-                  Planned for 2024
-                </h1>
               </a>
 
-              
-              <div className="payment3" style={{ opacity: 0.5 }}>
-                <div className="payment-row"></div>
+              <div className='payment3'>
+                <div
+                  className='payment-row'
+                  style={{
+                    display: 'flex',
+                    gap: '1rem',
+                    justifyContent: 'center',
+                    flexWrap: 'wrap'
+                  }}
+                >
+                  <a
+                    href='#'
+                    data-cb-type='checkout'
+                    data-cb-item-0='Family-USD-Monthly'
+                    data-cb-item-0-quantity='1'
+                    className='subscribe'
+                    onClick={e => e.preventDefault()}
+                  >
+                    Subscribe Monthly - $19.99/mo
+                  </a>
+                  <a
+                    href='#'
+                    data-cb-type='checkout'
+                    data-cb-item-0='Family-USD-Yearly'
+                    data-cb-item-0-quantity='1'
+                    className='subscribe'
+                    onClick={e => e.preventDefault()}
+                  >
+                    Subscribe Yearly - $X/yr
+                  </a>
+                </div>
               </div>
             </div>
 
             {/* FAQ Section for Personal Plans */}
-            <div className="personal-plans-faq" style={{ marginTop: '3rem', padding: '2rem', backgroundColor: 'rgba(0,0,0,0.1)', borderRadius: '10px' }}>
-              <h2 style={{ color: 'black', marginBottom: '1rem' }}>Frequently Asked Questions</h2>
-              
-              <div className="faq-item" style={{ marginBottom: '1rem' }}>
-                <h4 style={{ color: 'black', marginBottom: '0.5rem' }}>Q: What's the difference between personal and shop accounts?</h4>
+            <div
+              className='personal-plans-faq'
+              style={{
+                marginTop: '3rem',
+                padding: '2rem',
+                backgroundColor: 'rgba(0,0,0,0.1)',
+                borderRadius: '10px'
+              }}
+            >
+              <h2 style={{ color: 'black', marginBottom: '1rem' }}>
+                Frequently Asked Questions
+              </h2>
+
+              <div className='faq-item' style={{ marginBottom: '1rem' }}>
+                <h4 style={{ color: 'black', marginBottom: '0.5rem' }}>
+                  Q: What's the difference between personal and shop accounts?
+                </h4>
                 <p style={{ color: 'black' }}>
-                  A: Personal accounts are perfect for individual cyclists. Shop accounts allow bike shops to 
-                  invite customers and send automated maintenance notifications with the shop's contact information.
+                  A: Personal accounts are perfect for individual cyclists. Shop
+                  accounts allow bike shops to invite customers and send
+                  automated maintenance notifications with the shop's contact
+                  information.
                 </p>
               </div>
-              
-              <div className="faq-item" style={{ marginBottom: '1rem' }}>
-                <h4 style={{ color: 'black', marginBottom: '0.5rem' }}>Q: Can I upgrade from free to premium later?</h4>
+
+              <div className='faq-item' style={{ marginBottom: '1rem' }}>
+                <h4 style={{ color: 'black', marginBottom: '0.5rem' }}>
+                  Q: Can I upgrade from free to premium later?
+                </h4>
                 <p style={{ color: 'black' }}>
-                  A: Absolutely! When premium personal plans launch, you'll be able to upgrade seamlessly 
-                  while keeping all your existing data and settings.
+                  A: Absolutely! When premium personal plans launch, you'll be
+                  able to upgrade seamlessly while keeping all your existing
+                  data and settings.
                 </p>
               </div>
-              
-              <div className="faq-item">
-                <h4 style={{ color: 'black', marginBottom: '0.5rem' }}>Q: Do I need a bike shop to use KOR?</h4>
+
+              <div className='faq-item'>
+                <h4 style={{ color: 'black', marginBottom: '0.5rem' }}>
+                  Q: Do I need a bike shop to use KOR?
+                </h4>
                 <p style={{ color: 'black' }}>
-                  A: Not at all! Personal accounts work completely independently. However, if you have a 
-                  participating bike shop, they can provide additional features and support.
+                  A: Not at all! Personal accounts work completely
+                  independently. However, if you have a participating bike shop,
+                  they can provide additional features and support.
                 </p>
               </div>
             </div>
 
             {/* Call to Action */}
-            <div className="personal-cta-section" style={{ marginTop: '2rem', textAlign: 'center' }}>
-              <h2 style={{ color: 'black', marginBottom: '1rem' }}>Ready to Never Miss Maintenance Again?</h2>
-              <div className="app-store-buttons">
+            <div
+              className='personal-cta-section'
+              style={{ marginTop: '2rem', textAlign: 'center' }}
+            >
+              <h2 style={{ color: 'black', marginBottom: '1rem' }}>
+                Ready to Never Miss Maintenance Again?
+              </h2>
+              <div className='app-store-buttons'>
                 <a
-                  href="https://play.google.com/store/apps/details?id=com.robtuft.newKOR"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="store-button-link"
+                  href='https://play.google.com/store/apps/details?id=com.robtuft.newKOR'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='store-button-link'
                 >
                   <img
-                    className="store_buttons_large"
-                    src="/images/Google_play_button.svg"
-                    alt="Download on Google Play Store"
+                    className='store_buttons_large'
+                    src='/images/Google_play_button.svg'
+                    alt='Download on Google Play Store'
                   />
                 </a>
                 <a
-                  href="https://apps.apple.com/us/app/kor-keep-on-rolling/id1599601993"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="store-button-link"
+                  href='https://apps.apple.com/us/app/kor-keep-on-rolling/id1599601993'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='store-button-link'
                 >
                   <img
-                    className="store_buttons_large"
-                    src="/images/Apple_app_store_button.svg"
-                    alt="Download on App Store"
+                    className='store_buttons_large'
+                    src='/images/Apple_app_store_button.svg'
+                    alt='Download on App Store'
                   />
                 </a>
               </div>
               <p style={{ color: 'black', marginTop: '1rem' }}>
-                ✅ Free to download • 🔒 Secure Strava integration • 📱 Available on all devices
+                ✅ Free to download • 🔒 Secure Strava integration • 📱
+                Available on all devices
               </p>
             </div>
           </div>

--- a/kor-react/src/components/pages/PersonalPlans.tsx
+++ b/kor-react/src/components/pages/PersonalPlans.tsx
@@ -12,23 +12,36 @@ const PersonalPlans: React.FC = () => {
   const handleSubscribe = (planType: string) => {
     // For now, redirect to app stores for the free version
     // In the future, this could integrate with payment processing for premium personal plans
-    
-    const message = `You've selected the ${planType} plan. ` +
-      `${planType === 'free' 
-        ? 'Click OK to download the free version from your app store.' 
-        : 'Premium personal plans will be available soon. For now, enjoy the free version!'}`;
-    
+
+    const message =
+      `You've selected the ${planType} plan. ` +
+      `${
+        planType === 'free'
+          ? 'Click OK to download the free version from your app store.'
+          : 'Premium personal plans will be available soon. For now, enjoy the free version!'
+      }`;
+
     if (window.confirm(message)) {
       // Redirect to app stores
-      const userAgent = navigator.userAgent || navigator.vendor || (window as any).opera;
-      
+      const userAgent =
+        navigator.userAgent || navigator.vendor || (window as any).opera;
+
       if (/android/i.test(userAgent)) {
-        window.open('https://play.google.com/store/apps/details?id=com.robtuft.newKOR', '_blank');
+        window.open(
+          'https://play.google.com/store/apps/details?id=com.robtuft.newKOR',
+          '_blank'
+        );
       } else if (/iPad|iPhone|iPod/.test(userAgent)) {
-        window.open('https://apps.apple.com/us/app/kor-keep-on-rolling/id1599601993', '_blank');
+        window.open(
+          'https://apps.apple.com/us/app/kor-keep-on-rolling/id1599601993',
+          '_blank'
+        );
       } else {
         // Default to Google Play for desktop users
-        window.open('https://play.google.com/store/apps/details?id=com.robtuft.newKOR', '_blank');
+        window.open(
+          'https://play.google.com/store/apps/details?id=com.robtuft.newKOR',
+          '_blank'
+        );
       }
     }
   };
@@ -36,64 +49,67 @@ const PersonalPlans: React.FC = () => {
   return (
     <>
       <StructuredData
-        type="website"
-        pageTitle="Personal Account Plans — KOR"
-        pageDescription="Track your bike maintenance for free today. Premium plans coming soon with advanced features and notifications."
+        type='website'
+        pageTitle='Personal Account Plans — KOR'
+        pageDescription='Track your bike maintenance for free today. Premium plans coming soon with advanced features and notifications.'
         url={`${baseUrl}/personal-plans`}
       />
-      <div className="parallax_parent">
-        <div className="parallax_sign_up">
+      <div className='parallax_parent'>
+        <div className='parallax_sign_up'>
           <div style={{ padding: '5%' }}>
-            <h1 className="title_box">Personal Account Plans</h1>
-            <div className="mobile_textbox">
-              <p className="paragraph">
-                Perfect for individual cyclists who want to track their bike maintenance 
-                without a bike shop partnership. Get started with our free version or 
-                upgrade to premium features for enhanced tracking and notifications.
+            <h1 className='title_box'>Personal Account Plans</h1>
+            <div className='mobile_textbox'>
+              <p className='paragraph'>
+                Perfect for individual cyclists who want to track their bike
+                maintenance without a bike shop partnership. Get started with
+                our free version or upgrade to premium features for enhanced
+                tracking and notifications.
               </p>
             </div>
           </div>
         </div>
       </div>
-      
-      <div className="parallax_parent">
-        <div className="parallax2_sign_up">
+
+      <div className='parallax_parent'>
+        <div className='parallax2_sign_up'>
           <div style={{ padding: '5%' }}>
-            <div className="payment-plans">
+            <div className='payment-plans'>
               {/* Free Plan */}
-              <div className={`payment-card1 ${selectedPlan === 'free' ? 'selected' : ''}`}>
+              <div
+                className={`payment-card1 ${selectedPlan === 'free' ? 'selected' : ''}`}
+              >
                 <h1>Free</h1>
-                <h2 className="title">$0/month</h2>
-                <h2 className="title">Features</h2>
-                <ul className="list">
+                <h2 className='title'>$0/month</h2>
+                <h2 className='title'>Features</h2>
+                <ul className='list'>
                   <li>Basic component tracking</li>
                   <li>Strava integration</li>
                   <li>Manual maintenance logging</li>
                   <li>Basic wear percentage alerts</li>
                   <li>Single bike support</li>
                 </ul>
-                <div className="plan-limitations">
-                  <h3 className="limitation-title">Limitations:</h3>
-                  <ul className="limitation-list">
+                <div className='plan-limitations'>
+                  <h3 className='limitation-title'>Limitations:</h3>
+                  <ul className='limitation-list'>
                     <li>Limited to basic components</li>
                     <li>Manual notifications only</li>
                     <li>No advanced analytics</li>
                   </ul>
                 </div>
               </div>
-              
-              <div className="payment1">
-                <div className="payment-row">
+
+              <div className='payment1'>
+                <div className='payment-row'>
                   <button
-                    type="button"
+                    type='button'
                     className={`subscribe ${selectedPlan === 'free' ? 'selected' : ''}`}
                     onClick={() => handlePlanSelect('free')}
                   >
                     {selectedPlan === 'free' ? 'Selected' : 'Select Free Plan'}
                   </button>
                   <button
-                    type="button"
-                    className="subscribe primary"
+                    type='button'
+                    className='subscribe primary'
                     onClick={() => handleSubscribe('free')}
                   >
                     Download Free App
@@ -103,15 +119,15 @@ const PersonalPlans: React.FC = () => {
 
               {/* Premium Plan (Coming Soon) */}
               {/* Premium Plan (Coming Soon) */}
-              <a 
-                href="/premium-plan" 
-                className={`payment-card2 ${selectedPlan === 'premium' ? 'selected' : ''}`} 
+              <a
+                href='/premium-plan'
+                className={`payment-card2 ${selectedPlan === 'premium' ? 'selected' : ''}`}
                 style={{ opacity: 0.8 }}
               >
                 <h1>Premium</h1>
-                <h2 className="title">$9.99/month</h2>
-                <h2 className="title">Features</h2>
-                <ul className="list">
+                <h2 className='title'>$9.99/month</h2>
+                <h2 className='title'>Features</h2>
+                <ul className='list'>
                   <li>All Free features</li>
                   <li>Advanced component tracking</li>
                   <li>Automated email/push notifications</li>
@@ -121,113 +137,152 @@ const PersonalPlans: React.FC = () => {
                   <li>Weather-based adjustments</li>
                   <li>Component replacement reminders</li>
                 </ul>
-                <div className="coming-soon-badge">
+                <div className='coming-soon-badge'>
                   <span>Coming Soon!</span>
                 </div>
               </a>
 
-              
-              <div className="payment2" style={{ opacity: 0.8 }}>
-                <div className="payment-row">
-                  <button
-                    type="button"
-                    className="subscribe disabled"
-                    disabled
-                  >
+              <div className='payment2' style={{ opacity: 0.8 }}>
+                <div className='payment-row'>
+                  <button type='button' className='subscribe disabled' disabled>
                     Coming Soon
                   </button>
-                  <p className="coming-soon-text">
-                    Premium personal plans will be available in Q2 2024. 
-                    Join our free version now and get notified when premium launches!
+                  <p className='coming-soon-text'>
+                    Premium personal plans will be available in Q2 2024. Join
+                    our free version now and get notified when premium launches!
                   </p>
                 </div>
               </div>
 
-              {/* Family Plan (Future) */}
-              <a href="/family-plan" className="payment-card3" style={{ opacity: 0.5 }}>
+              {/* Family Plan - Now Available! */}
+              <div
+                className={`payment-card3 ${selectedPlan === 'family' ? 'selected' : ''}`}
+              >
                 <h1>Family</h1>
-                <h2 className="title">$19.99/month</h2>
-                <h2 className="title">Features</h2>
-                <ul className="list">
-                  <li>All Premium features</li>
+                <h2 className='title'>$X/month</h2>
+                <h2 className='title'>Features</h2>
+                <ul className='list'>
+                  <li>Up to 6 family members/riders</li>
                   <li>Unlimited bikes</li>
-                  <li>Team/family sharing up to 6 total users</li>
-                  <li>Advanced part recommendations</li>
-                  <li>Integration with bike shop networks</li>
-                  <li>Priority customer support</li>
-                  <li>Custom component databases</li>
+                  <li>Comprehensive maintenance tracking</li>
+                  <li>Automated wear notifications</li>
+                  <li>Shared maintenance history</li>
+                  <li>Family dashboard</li>
+                  <li>QR code for easy onboarding</li>
+                  <li>Email support</li>
                 </ul>
-                <h1 style={{ bottom: '30%', opacity: 1 }}>
-                  Planned for 2024
-                </h1>
-              </a>
+              </div>
 
-              
-              <div className="payment3" style={{ opacity: 0.5 }}>
-                <div className="payment-row"></div>
+              <div className='payment3'>
+                <div className='payment-row'>
+                  <button
+                    type='button'
+                    className={`subscribe ${selectedPlan === 'family' ? 'selected' : ''}`}
+                    onClick={() => handlePlanSelect('family')}
+                  >
+                    {selectedPlan === 'family'
+                      ? 'Selected'
+                      : 'Select Family Plan'}
+                  </button>
+                  <button
+                    type='button'
+                    className='subscribe primary'
+                    onClick={() =>
+                      (window.location.href = '/family-plan-pricing')
+                    }
+                  >
+                    Sign Up for Family Plan
+                  </button>
+                </div>
               </div>
             </div>
 
             {/* FAQ Section for Personal Plans */}
-            <div className="personal-plans-faq" style={{ marginTop: '3rem', padding: '2rem', backgroundColor: 'rgba(0,0,0,0.1)', borderRadius: '10px' }}>
-              <h2 style={{ color: 'black', marginBottom: '1rem' }}>Frequently Asked Questions</h2>
-              
-              <div className="faq-item" style={{ marginBottom: '1rem' }}>
-                <h4 style={{ color: 'black', marginBottom: '0.5rem' }}>Q: What's the difference between personal and shop accounts?</h4>
+            <div
+              className='personal-plans-faq'
+              style={{
+                marginTop: '3rem',
+                padding: '2rem',
+                backgroundColor: 'rgba(0,0,0,0.1)',
+                borderRadius: '10px'
+              }}
+            >
+              <h2 style={{ color: 'black', marginBottom: '1rem' }}>
+                Frequently Asked Questions
+              </h2>
+
+              <div className='faq-item' style={{ marginBottom: '1rem' }}>
+                <h4 style={{ color: 'black', marginBottom: '0.5rem' }}>
+                  Q: What's the difference between personal and shop accounts?
+                </h4>
                 <p style={{ color: 'black' }}>
-                  A: Personal accounts are perfect for individual cyclists. Shop accounts allow bike shops to 
-                  invite customers and send automated maintenance notifications with the shop's contact information.
+                  A: Personal accounts are perfect for individual cyclists. Shop
+                  accounts allow bike shops to invite customers and send
+                  automated maintenance notifications with the shop's contact
+                  information.
                 </p>
               </div>
-              
-              <div className="faq-item" style={{ marginBottom: '1rem' }}>
-                <h4 style={{ color: 'black', marginBottom: '0.5rem' }}>Q: Can I upgrade from free to premium later?</h4>
+
+              <div className='faq-item' style={{ marginBottom: '1rem' }}>
+                <h4 style={{ color: 'black', marginBottom: '0.5rem' }}>
+                  Q: Can I upgrade from free to premium later?
+                </h4>
                 <p style={{ color: 'black' }}>
-                  A: Absolutely! When premium personal plans launch, you'll be able to upgrade seamlessly 
-                  while keeping all your existing data and settings.
+                  A: Absolutely! When premium personal plans launch, you'll be
+                  able to upgrade seamlessly while keeping all your existing
+                  data and settings.
                 </p>
               </div>
-              
-              <div className="faq-item">
-                <h4 style={{ color: 'black', marginBottom: '0.5rem' }}>Q: Do I need a bike shop to use KOR?</h4>
+
+              <div className='faq-item'>
+                <h4 style={{ color: 'black', marginBottom: '0.5rem' }}>
+                  Q: Do I need a bike shop to use KOR?
+                </h4>
                 <p style={{ color: 'black' }}>
-                  A: Not at all! Personal accounts work completely independently. However, if you have a 
-                  participating bike shop, they can provide additional features and support.
+                  A: Not at all! Personal accounts work completely
+                  independently. However, if you have a participating bike shop,
+                  they can provide additional features and support.
                 </p>
               </div>
             </div>
 
             {/* Call to Action */}
-            <div className="personal-cta-section" style={{ marginTop: '2rem', textAlign: 'center' }}>
-              <h2 style={{ color: 'black', marginBottom: '1rem' }}>Ready to Never Miss Maintenance Again?</h2>
-              <div className="app-store-buttons">
+            <div
+              className='personal-cta-section'
+              style={{ marginTop: '2rem', textAlign: 'center' }}
+            >
+              <h2 style={{ color: 'black', marginBottom: '1rem' }}>
+                Ready to Never Miss Maintenance Again?
+              </h2>
+              <div className='app-store-buttons'>
                 <a
-                  href="https://play.google.com/store/apps/details?id=com.robtuft.newKOR"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="store-button-link"
+                  href='https://play.google.com/store/apps/details?id=com.robtuft.newKOR'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='store-button-link'
                 >
                   <img
-                    className="store_buttons_large"
-                    src="/images/Google_play_button.svg"
-                    alt="Download on Google Play Store"
+                    className='store_buttons_large'
+                    src='/images/Google_play_button.svg'
+                    alt='Download on Google Play Store'
                   />
                 </a>
                 <a
-                  href="https://apps.apple.com/us/app/kor-keep-on-rolling/id1599601993"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="store-button-link"
+                  href='https://apps.apple.com/us/app/kor-keep-on-rolling/id1599601993'
+                  target='_blank'
+                  rel='noopener noreferrer'
+                  className='store-button-link'
                 >
                   <img
-                    className="store_buttons_large"
-                    src="/images/Apple_app_store_button.svg"
-                    alt="Download on App Store"
+                    className='store_buttons_large'
+                    src='/images/Apple_app_store_button.svg'
+                    alt='Download on App Store'
                   />
                 </a>
               </div>
               <p style={{ color: 'black', marginTop: '1rem' }}>
-                ✅ Free to download • 🔒 Secure Strava integration • 📱 Available on all devices
+                ✅ Free to download • 🔒 Secure Strava integration • 📱
+                Available on all devices
               </p>
             </div>
           </div>

--- a/kor-react/src/components/pages/PersonalPlans.tsx
+++ b/kor-react/src/components/pages/PersonalPlans.tsx
@@ -33,28 +33,12 @@ const PersonalPlans: React.FC = () => {
           : 'Premium personal plans will be available soon. For now, enjoy the free version!'
       }`;
 
-
-    const message =
-      `You've selected the ${planType} plan. ` +
-      `${
-        planType === 'free'
-          ? 'Click OK to download the free version from your app store.'
-          : 'Premium personal plans will be available soon. For now, enjoy the free version!'
-      }`;
-
     if (window.confirm(message)) {
       // Redirect to app stores
       const userAgent =
         navigator.userAgent || navigator.vendor || (window as any).opera;
 
-      const userAgent =
-        navigator.userAgent || navigator.vendor || (window as any).opera;
-
       if (/android/i.test(userAgent)) {
-        window.open(
-          'https://play.google.com/store/apps/details?id=com.robtuft.newKOR',
-          '_blank'
-        );
         window.open(
           'https://play.google.com/store/apps/details?id=com.robtuft.newKOR',
           '_blank'
@@ -64,16 +48,8 @@ const PersonalPlans: React.FC = () => {
           'https://apps.apple.com/us/app/kor-keep-on-rolling/id1599601993',
           '_blank'
         );
-        window.open(
-          'https://apps.apple.com/us/app/kor-keep-on-rolling/id1599601993',
-          '_blank'
-        );
       } else {
         // Default to Google Play for desktop users
-        window.open(
-          'https://play.google.com/store/apps/details?id=com.robtuft.newKOR',
-          '_blank'
-        );
         window.open(
           'https://play.google.com/store/apps/details?id=com.robtuft.newKOR',
           '_blank'
@@ -88,23 +64,11 @@ const PersonalPlans: React.FC = () => {
         type='website'
         pageTitle='Personal Account Plans — KOR'
         pageDescription='Track your bike maintenance for free today. Premium plans coming soon with advanced features and notifications.'
-        type='website'
-        pageTitle='Personal Account Plans — KOR'
-        pageDescription='Track your bike maintenance for free today. Premium plans coming soon with advanced features and notifications.'
         url={`${baseUrl}/personal-plans`}
       />
       <div className='parallax_parent'>
         <div className='parallax_sign_up'>
-      <div className='parallax_parent'>
-        <div className='parallax_sign_up'>
           <div style={{ padding: '5%' }}>
-            <h1 className='title_box'>Personal Account Plans</h1>
-            <div className='mobile_textbox'>
-              <p className='paragraph'>
-                Perfect for individual cyclists who want to track their bike
-                maintenance without a bike shop partnership. Get started with
-                our free version or upgrade to premium features for enhanced
-                tracking and notifications.
             <h1 className='title_box'>Personal Account Plans</h1>
             <div className='mobile_textbox'>
               <p className='paragraph'>
@@ -120,23 +84,13 @@ const PersonalPlans: React.FC = () => {
 
       <div className='parallax_parent'>
         <div className='parallax2_sign_up'>
-
-      <div className='parallax_parent'>
-        <div className='parallax2_sign_up'>
           <div style={{ padding: '5%' }}>
-            <div className='payment-plans'>
             <div className='payment-plans'>
               {/* Free Plan */}
               <div
                 className={`payment-card1 ${selectedPlan === 'free' ? 'selected' : ''}`}
               >
-              <div
-                className={`payment-card1 ${selectedPlan === 'free' ? 'selected' : ''}`}
-              >
                 <h1>Free</h1>
-                <h2 className='title'>$0/month</h2>
-                <h2 className='title'>Features</h2>
-                <ul className='list'>
                 <h2 className='title'>$0/month</h2>
                 <h2 className='title'>Features</h2>
                 <ul className='list'>
@@ -149,9 +103,6 @@ const PersonalPlans: React.FC = () => {
                 <div className='plan-limitations'>
                   <h3 className='limitation-title'>Limitations:</h3>
                   <ul className='limitation-list'>
-                <div className='plan-limitations'>
-                  <h3 className='limitation-title'>Limitations:</h3>
-                  <ul className='limitation-list'>
                     <li>Limited to basic components</li>
                     <li>Manual notifications only</li>
                     <li>No advanced analytics</li>
@@ -161,11 +112,7 @@ const PersonalPlans: React.FC = () => {
 
               <div className='payment1'>
                 <div className='payment-row'>
-
-              <div className='payment1'>
-                <div className='payment-row'>
                   <button
-                    type='button'
                     type='button'
                     className={`subscribe ${selectedPlan === 'free' ? 'selected' : ''}`}
                     onClick={() => handlePlanSelect('free')}
@@ -173,8 +120,6 @@ const PersonalPlans: React.FC = () => {
                     {selectedPlan === 'free' ? 'Selected' : 'Select Free Plan'}
                   </button>
                   <button
-                    type='button'
-                    className='subscribe primary'
                     type='button'
                     className='subscribe primary'
                     onClick={() => handleSubscribe('free')}
@@ -185,19 +130,12 @@ const PersonalPlans: React.FC = () => {
               </div>
 
               {/* Premium Plan (Coming Soon) */}
-              {/* Premium Plan (Coming Soon) */}
-              <a
-                href='/premium-plan'
-                className={`payment-card2 ${selectedPlan === 'premium' ? 'selected' : ''}`}
               <a
                 href='/premium-plan'
                 className={`payment-card2 ${selectedPlan === 'premium' ? 'selected' : ''}`}
                 style={{ opacity: 0.8 }}
               >
                 <h1>Premium</h1>
-                <h2 className='title'>$9.99/month</h2>
-                <h2 className='title'>Features</h2>
-                <ul className='list'>
                 <h2 className='title'>$9.99/month</h2>
                 <h2 className='title'>Features</h2>
                 <ul className='list'>
@@ -211,7 +149,6 @@ const PersonalPlans: React.FC = () => {
                   <li>Component replacement reminders</li>
                 </ul>
                 <div className='coming-soon-badge'>
-                <div className='coming-soon-badge'>
                   <span>Coming Soon!</span>
                 </div>
               </a>
@@ -219,14 +156,8 @@ const PersonalPlans: React.FC = () => {
               <div className='payment2' style={{ opacity: 0.8 }}>
                 <div className='payment-row'>
                   <button type='button' className='subscribe disabled' disabled>
-              <div className='payment2' style={{ opacity: 0.8 }}>
-                <div className='payment-row'>
-                  <button type='button' className='subscribe disabled' disabled>
                     Coming Soon
                   </button>
-                  <p className='coming-soon-text'>
-                    Premium personal plans will be available in Q2 2024. Join
-                    our free version now and get notified when premium launches!
                   <p className='coming-soon-text'>
                     Premium personal plans will be available in Q2 2024. Join
                     our free version now and get notified when premium launches!
@@ -311,28 +242,7 @@ const PersonalPlans: React.FC = () => {
                 <h4 style={{ color: 'black', marginBottom: '0.5rem' }}>
                   Q: What's the difference between personal and shop accounts?
                 </h4>
-            <div
-              className='personal-plans-faq'
-              style={{
-                marginTop: '3rem',
-                padding: '2rem',
-                backgroundColor: 'rgba(0,0,0,0.1)',
-                borderRadius: '10px'
-              }}
-            >
-              <h2 style={{ color: 'black', marginBottom: '1rem' }}>
-                Frequently Asked Questions
-              </h2>
-
-              <div className='faq-item' style={{ marginBottom: '1rem' }}>
-                <h4 style={{ color: 'black', marginBottom: '0.5rem' }}>
-                  Q: What's the difference between personal and shop accounts?
-                </h4>
                 <p style={{ color: 'black' }}>
-                  A: Personal accounts are perfect for individual cyclists. Shop
-                  accounts allow bike shops to invite customers and send
-                  automated maintenance notifications with the shop's contact
-                  information.
                   A: Personal accounts are perfect for individual cyclists. Shop
                   accounts allow bike shops to invite customers and send
                   automated maintenance notifications with the shop's contact
@@ -344,15 +254,7 @@ const PersonalPlans: React.FC = () => {
                 <h4 style={{ color: 'black', marginBottom: '0.5rem' }}>
                   Q: Can I upgrade from free to premium later?
                 </h4>
-
-              <div className='faq-item' style={{ marginBottom: '1rem' }}>
-                <h4 style={{ color: 'black', marginBottom: '0.5rem' }}>
-                  Q: Can I upgrade from free to premium later?
-                </h4>
                 <p style={{ color: 'black' }}>
-                  A: Absolutely! When premium personal plans launch, you'll be
-                  able to upgrade seamlessly while keeping all your existing
-                  data and settings.
                   A: Absolutely! When premium personal plans launch, you'll be
                   able to upgrade seamlessly while keeping all your existing
                   data and settings.
@@ -363,15 +265,7 @@ const PersonalPlans: React.FC = () => {
                 <h4 style={{ color: 'black', marginBottom: '0.5rem' }}>
                   Q: Do I need a bike shop to use KOR?
                 </h4>
-
-              <div className='faq-item'>
-                <h4 style={{ color: 'black', marginBottom: '0.5rem' }}>
-                  Q: Do I need a bike shop to use KOR?
-                </h4>
                 <p style={{ color: 'black' }}>
-                  A: Not at all! Personal accounts work completely
-                  independently. However, if you have a participating bike shop,
-                  they can provide additional features and support.
                   A: Not at all! Personal accounts work completely
                   independently. However, if you have a participating bike shop,
                   they can provide additional features and support.
@@ -388,28 +282,13 @@ const PersonalPlans: React.FC = () => {
                 Ready to Never Miss Maintenance Again?
               </h2>
               <div className='app-store-buttons'>
-            <div
-              className='personal-cta-section'
-              style={{ marginTop: '2rem', textAlign: 'center' }}
-            >
-              <h2 style={{ color: 'black', marginBottom: '1rem' }}>
-                Ready to Never Miss Maintenance Again?
-              </h2>
-              <div className='app-store-buttons'>
                 <a
-                  href='https://play.google.com/store/apps/details?id=com.robtuft.newKOR'
-                  target='_blank'
-                  rel='noopener noreferrer'
-                  className='store-button-link'
                   href='https://play.google.com/store/apps/details?id=com.robtuft.newKOR'
                   target='_blank'
                   rel='noopener noreferrer'
                   className='store-button-link'
                 >
                   <img
-                    className='store_buttons_large'
-                    src='/images/Google_play_button.svg'
-                    alt='Download on Google Play Store'
                     className='store_buttons_large'
                     src='/images/Google_play_button.svg'
                     alt='Download on Google Play Store'
@@ -420,15 +299,8 @@ const PersonalPlans: React.FC = () => {
                   target='_blank'
                   rel='noopener noreferrer'
                   className='store-button-link'
-                  href='https://apps.apple.com/us/app/kor-keep-on-rolling/id1599601993'
-                  target='_blank'
-                  rel='noopener noreferrer'
-                  className='store-button-link'
                 >
                   <img
-                    className='store_buttons_large'
-                    src='/images/Apple_app_store_button.svg'
-                    alt='Download on App Store'
                     className='store_buttons_large'
                     src='/images/Apple_app_store_button.svg'
                     alt='Download on App Store'
@@ -436,8 +308,6 @@ const PersonalPlans: React.FC = () => {
                 </a>
               </div>
               <p style={{ color: 'black', marginTop: '1rem' }}>
-                ✅ Free to download • 🔒 Secure Strava integration • 📱
-                Available on all devices
                 ✅ Free to download • 🔒 Secure Strava integration • 📱
                 Available on all devices
               </p>

--- a/kor-react/src/components/pages/PersonalPlans.tsx
+++ b/kor-react/src/components/pages/PersonalPlans.tsx
@@ -171,7 +171,6 @@ const PersonalPlans: React.FC = () => {
                 className={`payment-card3 ${selectedPlan === 'family' ? 'selected' : ''}`}
                 onClick={e => {
                   e.preventDefault();
-                  setSelectedPlan('family');
                   window.location.href = '/family-plan-pricing';
                 }}
               >
@@ -203,7 +202,7 @@ const PersonalPlans: React.FC = () => {
                   <a
                     href='#'
                     data-cb-type='checkout'
-                    data-cb-item-0='Family-USD-Monthly'
+                    data-cb-item-0='family-USD-Monthly'
                     data-cb-item-0-quantity='1'
                     className='subscribe'
                     onClick={e => e.preventDefault()}
@@ -213,7 +212,7 @@ const PersonalPlans: React.FC = () => {
                   <a
                     href='#'
                     data-cb-type='checkout'
-                    data-cb-item-0='Family-USD-Yearly'
+                    data-cb-item-0='family-USD-Yearly'
                     data-cb-item-0-quantity='1'
                     className='subscribe'
                     onClick={e => e.preventDefault()}

--- a/kor-react/src/components/pages/SignUp.tsx
+++ b/kor-react/src/components/pages/SignUp.tsx
@@ -1,12 +1,5 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import StructuredData from '../common/StructuredData';
-
-// Declare Chargebee as a global variable for TypeScript
-declare global {
-  interface Window {
-    Chargebee: any;
-  }
-}
 
 const SignUp: React.FC = () => {
   const [demoFormData, setDemoFormData] = useState({
@@ -20,47 +13,19 @@ const SignUp: React.FC = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitMessage, setSubmitMessage] = useState('');
 
-  useEffect(() => {
-    // Initialize Chargebee when component mounts
-    if (window.Chargebee) {
-      const site = process.env.REACT_APP_CHARGEBEE_SITE || 'jmrcycling';
-      const publishableKey = process.env.REACT_APP_CHARGEBEE_PUBLISHABLE_KEY;
-
-      const initConfig: any = { site };
-      if (publishableKey) {
-        initConfig.publishableKey = publishableKey;
-      }
-
-      window.Chargebee.init(initConfig);
-
-      const isProduction = process.env.REACT_APP_ENVIRONMENT === 'production' || process.env.NODE_ENV === 'production';
-      if (!publishableKey) {
-        if (isProduction) {
-          console.warn('Chargebee publishable key is not configured. Some checkout features may not work in production.');
-        } else {
-          console.log('Chargebee publishable key not set - assuming development mode.');
-        }
-      }
-
-      console.log(`Chargebee initialized with site: ${site}${publishableKey ? ' and publishable key' : ''}`);
-    } else {
-      console.warn('Chargebee not loaded - using development fallback mode');
-    }
-  }, []);
-
   const baseUrl = process.env.REACT_APP_SITE_URL || 'https://jmrcycling.com';
 
   const handleDemoSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsSubmitting(true);
     setSubmitMessage('');
-    
+
     try {
       const formspreeId = process.env.REACT_APP_FORMSPREE_ID || 'myyvklzv';
       const response = await fetch(`https://formspree.io/f/${formspreeId}`, {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json',
+          'Content-Type': 'application/json'
         },
         body: JSON.stringify({
           shopName: demoFormData.shopName,
@@ -70,184 +35,223 @@ const SignUp: React.FC = () => {
           message: demoFormData.message,
           _replyto: demoFormData.email,
           _subject: `KOR Shop Demo Request: ${demoFormData.shopName}`
-        }),
+        })
       });
-      
+
       if (response.ok) {
-        setSubmitMessage('Demo request submitted successfully! We\'ll contact you within 48 hours.');
-        setDemoFormData({ shopName: '', contactName: '', email: '', phone: '', message: '' });
+        setSubmitMessage(
+          "Demo request submitted successfully! We'll contact you within 48 hours."
+        );
+        setDemoFormData({
+          shopName: '',
+          contactName: '',
+          email: '',
+          phone: '',
+          message: ''
+        });
       } else {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
     } catch (error) {
       console.error('Form submission error:', error);
-      setSubmitMessage('Error submitting request. Please try again or email us directly.');
+      setSubmitMessage(
+        'Error submitting request. Please try again or email us directly.'
+      );
     } finally {
       setIsSubmitting(false);
     }
   };
 
-  const handleDemoChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+  const handleDemoChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
     setDemoFormData({
       ...demoFormData,
       [e.target.name]: e.target.value
     });
   };
 
-  const handleSubscription = (planType: string, billingCycle: string) => {
-    console.log(`Attempting to subscribe to ${planType} - ${billingCycle}`);
-    
-    // Check if we're in development mode or Chargebee isn't configured
-    const isDevelopment = process.env.REACT_APP_ENVIRONMENT === 'development';
-    
-    if (!window.Chargebee) {
-      if (isDevelopment) {
-        // Development fallback - show a modal or redirect to a test page
-        const confirmed = window.confirm(
-          `Development Mode:\n\nYou're trying to subscribe to:\n${planType} - ${billingCycle}\n\nThis would normally open Chargebee checkout.\n\nClick OK to simulate successful subscription, or Cancel to abort.`
-        );
-        
-        if (confirmed) {
-          // Simulate successful subscription in development
-          alert('Simulated successful subscription! Redirecting to dashboard...');
-          window.location.href = '/shop/dashboard?success=true&plan=' + encodeURIComponent(`${planType}-${billingCycle}`);
-        }
-        return;
-      } else {
-        alert('Payment system is not available. Please try again in a moment or contact support.');
-        return;
-      }
-    }
-
-    // Map plan types to Chargebee plan IDs
-    const planMap: { [key: string]: string } = {
-      'Basic-Monthly': 'Basic-USD-Monthly',
-      'Basic-Yearly': 'Basic-Plan-USD-Yearly', 
-      'Premium-Monthly': 'Premium-USD-Monthly',
-      'Premium-Yearly': 'Premium-USD-Yearly'
-    };
-
-    const planId = planMap[`${planType}-${billingCycle}`];
-    
-    if (!planId) {
-      console.error('Plan ID not found for:', planType, billingCycle);
-      alert('Plan configuration error. Please contact support.');
-      return;
-    }
-
-    try {
-      // Initialize Chargebee instance if not already done
-      const cbInstance = window.Chargebee.getInstance();
-      
-      if (!cbInstance) {
-        alert('Payment system initialization error. Please refresh the page and try again.');
-        return;
-      }
-
-      // Open Chargebee checkout
-      cbInstance.openCheckout({
-        hostedPage: () => {
-          // This should return a hosted page object from your backend
-          // For now, we'll attempt to create a basic checkout configuration
-          return {
-            id: planId,
-            type: 'checkout_new_subscription',
-            embed: false,
-            success_url: `${window.location.origin}/shop/dashboard?success=true`,
-            cancel_url: `${window.location.origin}/sign-up?cancelled=true`
-          };
-        },
-        success: (hostedPageId: string) => {
-          console.log('Checkout successful:', hostedPageId);
-          window.location.href = `/shop/dashboard?success=true&subscription=${hostedPageId}`;
-        },
-        error: (error: any) => {
-          console.error('Checkout error:', error);
-          alert('There was an error processing your subscription. Please try again or contact support.');
-        },
-        close: () => {
-          console.log('Checkout closed by user');
-        }
-      });
-    } catch (error) {
-      console.error('Error opening Chargebee checkout:', error);
-      
-      if (isDevelopment) {
-        alert('Chargebee configuration error in development. Using fallback simulation.');
-        const confirmed = window.confirm(`Simulate subscription to ${planType} - ${billingCycle}?`);
-        if (confirmed) {
-          window.location.href = '/shop/dashboard?success=true&plan=' + encodeURIComponent(`${planType}-${billingCycle}`);
-        }
-      } else {
-        alert('Unable to open checkout. Please contact support.');
-      }
-    }
-  };
 
   return (
     <>
       <StructuredData
-        type="website"
-        pageTitle="Shop Sign Up — KOR"
-        pageDescription="Partner with KOR to invite customers, automate maintenance notifications, and enhance service."
+        type='website'
+        pageTitle='Shop Sign Up — KOR'
+        pageDescription='Partner with KOR to invite customers, automate maintenance notifications, and enhance service.'
         url={`${baseUrl}/sign-up`}
       />
-      <div className="parallax_parent">
-        <div className="parallax_sign_up">
+      <div className='parallax_parent'>
+        <div className='parallax_sign_up'>
           <div style={{ padding: '5%' }}>
-            <h1 className="title_box">Shop Sign Up</h1>
-            <div className="mobile_textbox">
-              <p className="paragraph" style={{ fontSize: '1.1em', marginBottom: '0.8em', color: '#e0e0e0' }}>
-                KOR tracks your customers' component wear from Strava in the background, automatically alerting them when service is due.
+            <h1 className='title_box'>Shop Sign Up</h1>
+            <div className='mobile_textbox'>
+              <p
+                className='paragraph'
+                style={{
+                  fontSize: '1.1em',
+                  marginBottom: '0.8em',
+                  color: '#e0e0e0'
+                }}
+              >
+                KOR tracks your customers' component wear from Strava in the
+                background, automatically alerting them when service is due.
               </p>
-              <p className="paragraph" style={{ fontWeight: 600, marginBottom: '0.5em', fontSize: '1.3em' }}>
-                Turn your customers' Strava rides into automated maintenance revenue and stronger relationships.
+              <p
+                className='paragraph'
+                style={{
+                  fontWeight: 600,
+                  marginBottom: '0.5em',
+                  fontSize: '1.3em'
+                }}
+              >
+                Turn your customers' Strava rides into automated maintenance
+                revenue and stronger relationships.
               </p>
-              <p className="paragraph" style={{ fontSize: '1.2em', fontWeight: 700, color: '#4CAF50', marginTop: '1em' }}>
+              <p
+                className='paragraph'
+                style={{
+                  fontSize: '1.2em',
+                  fontWeight: 700,
+                  color: '#4CAF50',
+                  marginTop: '1em'
+                }}
+              >
                 KOR can have an increase of up to 30% in service revenue.
               </p>
             </div>
             {/* How It Works Section */}
-            <div className="mobile_textbox" style={{ marginTop: '3em', marginBottom: '2em', backgroundColor: 'rgba(255,255,255,0.1)', padding: '2em', borderRadius: '10px' }}>
-              <h2 style={{ color: 'white', textAlign: 'center', fontSize: '2em', marginBottom: '1em' }}>How KOR Works for Your Shop</h2>
-              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))', gap: '2em', maxWidth: '900px', margin: '0 auto' }}>
+            <div
+              className='mobile_textbox'
+              style={{
+                marginTop: '3em',
+                marginBottom: '2em',
+                backgroundColor: 'rgba(255,255,255,0.1)',
+                padding: '2em',
+                borderRadius: '10px'
+              }}
+            >
+              <h2
+                style={{
+                  color: 'white',
+                  textAlign: 'center',
+                  fontSize: '2em',
+                  marginBottom: '1em'
+                }}
+              >
+                How KOR Works for Your Shop
+              </h2>
+              <div
+                style={{
+                  display: 'grid',
+                  gridTemplateColumns: 'repeat(auto-fit, minmax(250px, 1fr))',
+                  gap: '2em',
+                  maxWidth: '900px',
+                  margin: '0 auto'
+                }}
+              >
                 <div style={{ textAlign: 'center' }}>
-                  <h3 style={{ color: 'white', fontSize: '1.3em', marginBottom: '0.5em' }}>1. Invite Customers</h3>
-                  <p style={{ color: '#e0e0e0', fontSize: '1em' }}><strong>Invite customers at the counter.</strong> Share your unique shop code when they purchase or service their bikes.</p>
+                  <h3
+                    style={{
+                      color: 'white',
+                      fontSize: '1.3em',
+                      marginBottom: '0.5em'
+                    }}
+                  >
+                    1. Invite Customers
+                  </h3>
+                  <p style={{ color: '#e0e0e0', fontSize: '1em' }}>
+                    <strong>Invite customers at the counter.</strong> Share your
+                    unique shop code when they purchase or service their bikes.
+                  </p>
                 </div>
                 <div style={{ textAlign: 'center' }}>
-                  <h3 style={{ color: 'white', fontSize: '1.3em', marginBottom: '0.5em' }}>2. Automatic Tracking</h3>
-                  <p style={{ color: '#e0e0e0', fontSize: '1em' }}><strong>KOR syncs with Strava.</strong> Component wear is tracked on every ride with no manual input needed.</p>
+                  <h3
+                    style={{
+                      color: 'white',
+                      fontSize: '1.3em',
+                      marginBottom: '0.5em'
+                    }}
+                  >
+                    2. Automatic Tracking
+                  </h3>
+                  <p style={{ color: '#e0e0e0', fontSize: '1em' }}>
+                    <strong>KOR syncs with Strava.</strong> Component wear is
+                    tracked on every ride with no manual input needed.
+                  </p>
                 </div>
                 <div style={{ textAlign: 'center' }}>
-                  <h3 style={{ color: 'white', fontSize: '1.3em', marginBottom: '0.5em' }}>3. Timely Reminders</h3>
-                  <p style={{ color: '#e0e0e0', fontSize: '1em' }}><strong>Customers get alerts before failure.</strong> Shop-branded notifications tell them when parts need service.</p>
+                  <h3
+                    style={{
+                      color: 'white',
+                      fontSize: '1.3em',
+                      marginBottom: '0.5em'
+                    }}
+                  >
+                    3. Timely Reminders
+                  </h3>
+                  <p style={{ color: '#e0e0e0', fontSize: '1em' }}>
+                    <strong>Customers get alerts before failure.</strong>{' '}
+                    Shop-branded notifications tell them when parts need
+                    service.
+                  </p>
                 </div>
                 <div style={{ textAlign: 'center' }}>
-                  <h3 style={{ color: 'white', fontSize: '1.3em', marginBottom: '0.5em' }}>4. More Revenue</h3>
-                  <p style={{ color: '#e0e0e0', fontSize: '1em' }}><strong>Fill your service schedule proactively.</strong> Book maintenance appointments instead of waiting for reactive repairs.</p>
+                  <h3
+                    style={{
+                      color: 'white',
+                      fontSize: '1.3em',
+                      marginBottom: '0.5em'
+                    }}
+                  >
+                    4. More Revenue
+                  </h3>
+                  <p style={{ color: '#e0e0e0', fontSize: '1em' }}>
+                    <strong>Fill your service schedule proactively.</strong>{' '}
+                    Book maintenance appointments instead of waiting for
+                    reactive repairs.
+                  </p>
                 </div>
               </div>
             </div>
           </div>
         </div>
       </div>
-      
-      <div className="parallax_parent">
-        <div className="parallax2_sign_up">
+
+      <div className='parallax_parent'>
+        <div className='parallax2_sign_up'>
           <div style={{ padding: '5%' }}>
-            <div className="mobile_textbox" style={{ marginBottom: '3em' }}>
-              <h2 style={{ color: 'white', textAlign: 'center', fontSize: '2em', marginBottom: '1em' }}>Choose Your Plan</h2>
-              <p className="paragraph" style={{ marginBottom: '2em' }}>
-                Most shops lose service revenue because customers only come in after parts fail—KOR helps you reach them before that point with automated, shop-branded maintenance reminders.
+            <div className='mobile_textbox' style={{ marginBottom: '3em' }}>
+              <h2
+                style={{
+                  color: 'white',
+                  textAlign: 'center',
+                  fontSize: '2em',
+                  marginBottom: '1em'
+                }}
+              >
+                Choose Your Plan
+              </h2>
+              <p className='paragraph' style={{ marginBottom: '2em' }}>
+                Most shops lose service revenue because customers only come in
+                after parts fail—KOR helps you reach them before that point with
+                automated, shop-branded maintenance reminders.
               </p>
             </div>
-            <div className="payment-plans">
-              <div className="payment-card1">
+            <div className='payment-plans'>
+              <div className='payment-card1'>
                 <h1>Basic</h1>
                 {/*<h2 className="title">$40/month</h2>*/}
-                <p className="paragraph" style={{ padding: '0 1em', marginBottom: '1em', fontSize: '0.95em' }}>
-                  Keep customers coming back with simple, automated notifications that tell them when their parts are worn and point them straight to your shop.
+                <p
+                  className='paragraph'
+                  style={{
+                    padding: '0 1em',
+                    marginBottom: '1em',
+                    fontSize: '0.95em'
+                  }}
+                >
+                  Keep customers coming back with simple, automated
+                  notifications that tell them when their parts are worn and
+                  point them straight to your shop.
                 </p>
                 {/*<h2 className="title">Features</h2>*/}
                 {/*<ul className="list">*/}
@@ -286,11 +290,20 @@ const SignUp: React.FC = () => {
               {/*  </div>*/}
               {/*</div>*/}
 
-              <div className="payment-card2">
+              <div className='payment-card2'>
                 <h1>Premium</h1>
                 {/*<h2 className="title">$80/month</h2>*/}
-                <p className="paragraph" style={{ padding: '0 1em', marginBottom: '1em', fontSize: '0.95em' }}>
-                  Layer on customizable notifications so you can promote tune-up specials, seasonal service, and events to engaged riders already tracking their bikes with KOR.
+                <p
+                  className='paragraph'
+                  style={{
+                    padding: '0 1em',
+                    marginBottom: '1em',
+                    fontSize: '0.95em'
+                  }}
+                >
+                  Layer on customizable notifications so you can promote tune-up
+                  specials, seasonal service, and events to engaged riders
+                  already tracking their bikes with KOR.
                 </p>
                 {/*<h2 className="title">Features</h2>*/}
                 {/*<ul className="list">*/}
@@ -332,12 +345,20 @@ const SignUp: React.FC = () => {
               {/*    </button>*/}
               {/*  </div>*/}
               {/*</div>*/}
-              
-              <div className="payment-card3">
+
+              <div className='payment-card3'>
                 <h1>Pro</h1>
-                <p className="paragraph" style={{ padding: '0 1em', marginBottom: '1em', fontSize: '0.95em' }}>
-                  Gain pro-level insight into each customer's component wear so you can proactively recommend service
-                  and deliver a white-glove experience.
+                <p
+                  className='paragraph'
+                  style={{
+                    padding: '0 1em',
+                    marginBottom: '1em',
+                    fontSize: '0.95em'
+                  }}
+                >
+                  Gain pro-level insight into each customer's component wear so
+                  you can proactively recommend service and deliver a
+                  white-glove experience.
                 </p>
                 {/*<h2 className="title">Features</h2>*/}
                 {/*<ul className="list">*/}
@@ -366,109 +387,221 @@ const SignUp: React.FC = () => {
               {/*  </div>*/}
               {/*</div>*/}
             </div>
-            
 
-            
-            <div className="mobile_textbox" style={{paddingTop: '0.001em', marginTop: '2em', paddingBottom: '1em' }}>
+            <div
+              className='mobile_textbox'
+              style={{
+                paddingTop: '0.001em',
+                marginTop: '2em',
+                paddingBottom: '1em'
+              }}
+            >
               <h1>Request a Pressure Free Call From Our Founders</h1>
-              <p className="paragraph" style={{ fontStyle: 'italic', marginBottom: '2em' }}>
-                Spend less time chasing customers and more time booking profitable, well-timed service appointments with riders who feel taken care of by your shop.
+              <p
+                className='paragraph'
+                style={{ fontStyle: 'italic', marginBottom: '2em' }}
+              >
+                Spend less time chasing customers and more time booking
+                profitable, well-timed service appointments with riders who feel
+                taken care of by your shop.
               </p>
-              
+
               {submitMessage && (
-                <div className={`form-message ${submitMessage.includes('Error') ? 'error' : 'success'}`} style={{ 
-                  marginBottom: '1rem', 
-                  padding: '0.75rem', 
-                  borderRadius: '4px', 
-                  backgroundColor: submitMessage.includes('Error') ? '#ffe6e6' : '#e6f7e6',
-                  color: submitMessage.includes('Error') ? '#d63031' : '#00b894',
-                  border: `1px solid ${submitMessage.includes('Error') ? '#d63031' : '#00b894'}`
-                }}>
+                <div
+                  className={`form-message ${submitMessage.includes('Error') ? 'error' : 'success'}`}
+                  style={{
+                    marginBottom: '1rem',
+                    padding: '0.75rem',
+                    borderRadius: '4px',
+                    backgroundColor: submitMessage.includes('Error')
+                      ? '#ffe6e6'
+                      : '#e6f7e6',
+                    color: submitMessage.includes('Error')
+                      ? '#d63031'
+                      : '#00b894',
+                    border: `1px solid ${submitMessage.includes('Error') ? '#d63031' : '#00b894'}`
+                  }}
+                >
                   {submitMessage}
                 </div>
               )}
-              
+
               <form
-                action="https://formspree.io/f/myyvklzv"
-                method="post"
-                name="DemoRequestForm"
-                className="login_form"
+                action='https://formspree.io/f/myyvklzv'
+                method='post'
+                name='DemoRequestForm'
+                className='login_form'
                 onSubmit={handleDemoSubmit}
-                style={{ maxWidth: '600px', margin: '0 auto', paddingBottom: '2em' }}
+                style={{
+                  maxWidth: '600px',
+                  margin: '0 auto',
+                  paddingBottom: '2em'
+                }}
               >
-                <div className="form_line" style={{ display: 'flex', flexDirection: 'column', alignItems: 'stretch', textAlign: 'left' }}>
-                  <label htmlFor="shopName" style={{ marginBottom: '0.5em', fontWeight: 'bold' }}>Shop Name *</label>
+                <div
+                  className='form_line'
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'stretch',
+                    textAlign: 'left'
+                  }}
+                >
+                  <label
+                    htmlFor='shopName'
+                    style={{ marginBottom: '0.5em', fontWeight: 'bold' }}
+                  >
+                    Shop Name *
+                  </label>
                   <input
-                    type="text"
-                    id="shopName"
-                    name="shopName"
-                    placeholder="Your bike shop name"
+                    type='text'
+                    id='shopName'
+                    name='shopName'
+                    placeholder='Your bike shop name'
                     value={demoFormData.shopName}
                     onChange={handleDemoChange}
-                    style={{ padding: '0.75em', fontSize: '1em', borderRadius: '4px', border: '1px solid #ccc' }}
+                    style={{
+                      padding: '0.75em',
+                      fontSize: '1em',
+                      borderRadius: '4px',
+                      border: '1px solid #ccc'
+                    }}
                     required
                   />
                 </div>
-                
-                <div className="form_line" style={{ display: 'flex', flexDirection: 'column', alignItems: 'stretch', textAlign: 'left' }}>
-                  <label htmlFor="contactName" style={{ marginBottom: '0.5em', fontWeight: 'bold' }}>Contact Name *</label>
+
+                <div
+                  className='form_line'
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'stretch',
+                    textAlign: 'left'
+                  }}
+                >
+                  <label
+                    htmlFor='contactName'
+                    style={{ marginBottom: '0.5em', fontWeight: 'bold' }}
+                  >
+                    Contact Name *
+                  </label>
                   <input
-                    type="text"
-                    id="contactName"
-                    name="contactName"
-                    placeholder="Your full name"
+                    type='text'
+                    id='contactName'
+                    name='contactName'
+                    placeholder='Your full name'
                     value={demoFormData.contactName}
                     onChange={handleDemoChange}
-                    style={{ padding: '0.75em', fontSize: '1em', borderRadius: '4px', border: '1px solid #ccc' }}
+                    style={{
+                      padding: '0.75em',
+                      fontSize: '1em',
+                      borderRadius: '4px',
+                      border: '1px solid #ccc'
+                    }}
                     required
                   />
                 </div>
-                
-                <div className="form_line" style={{ display: 'flex', flexDirection: 'column', alignItems: 'stretch', textAlign: 'left' }}>
-                  <label htmlFor="email" style={{ marginBottom: '0.5em', fontWeight: 'bold' }}>Email *</label>
+
+                <div
+                  className='form_line'
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'stretch',
+                    textAlign: 'left'
+                  }}
+                >
+                  <label
+                    htmlFor='email'
+                    style={{ marginBottom: '0.5em', fontWeight: 'bold' }}
+                  >
+                    Email *
+                  </label>
                   <input
-                    type="email"
-                    id="email"
-                    name="email"
-                    placeholder="youraddress@example.com"
+                    type='email'
+                    id='email'
+                    name='email'
+                    placeholder='youraddress@example.com'
                     value={demoFormData.email}
                     onChange={handleDemoChange}
-                    style={{ padding: '0.75em', fontSize: '1em', borderRadius: '4px', border: '1px solid #ccc' }}
+                    style={{
+                      padding: '0.75em',
+                      fontSize: '1em',
+                      borderRadius: '4px',
+                      border: '1px solid #ccc'
+                    }}
                     required
                   />
                 </div>
-                
-                <div className="form_line" style={{ display: 'flex', flexDirection: 'column', alignItems: 'stretch', textAlign: 'left' }}>
-                  <label htmlFor="phone" style={{ marginBottom: '0.5em', fontWeight: 'bold' }}>Phone Number</label>
+
+                <div
+                  className='form_line'
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'stretch',
+                    textAlign: 'left'
+                  }}
+                >
+                  <label
+                    htmlFor='phone'
+                    style={{ marginBottom: '0.5em', fontWeight: 'bold' }}
+                  >
+                    Phone Number
+                  </label>
                   <input
-                    type="tel"
-                    id="phone"
-                    name="phone"
-                    placeholder="(123) 456-7890"
+                    type='tel'
+                    id='phone'
+                    name='phone'
+                    placeholder='(123) 456-7890'
                     value={demoFormData.phone}
                     onChange={handleDemoChange}
-                    style={{ padding: '0.75em', fontSize: '1em', borderRadius: '4px', border: '1px solid #ccc' }}
+                    style={{
+                      padding: '0.75em',
+                      fontSize: '1em',
+                      borderRadius: '4px',
+                      border: '1px solid #ccc'
+                    }}
                   />
                 </div>
-                
-                <div className="form_line" style={{ display: 'flex', flexDirection: 'column', alignItems: 'stretch', textAlign: 'left' }}>
-                  <label htmlFor="message" style={{ marginBottom: '0.5em', fontWeight: 'bold' }}>Tell us about your shop (optional)</label>
+
+                <div
+                  className='form_line'
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'stretch',
+                    textAlign: 'left'
+                  }}
+                >
+                  <label
+                    htmlFor='message'
+                    style={{ marginBottom: '0.5em', fontWeight: 'bold' }}
+                  >
+                    Tell us about your shop (optional)
+                  </label>
                   <textarea
-                    id="message"
-                    name="message"
+                    id='message'
+                    name='message'
                     placeholder="Number of customers and what you're looking for..."
                     rows={4}
                     value={demoFormData.message}
                     onChange={handleDemoChange}
-                    style={{ padding: '0.75em', fontSize: '1em', borderRadius: '4px', border: '1px solid #ccc', resize: 'vertical' }}
+                    style={{
+                      padding: '0.75em',
+                      fontSize: '1em',
+                      borderRadius: '4px',
+                      border: '1px solid #ccc',
+                      resize: 'vertical'
+                    }}
                   />
                 </div>
 
-                <button 
-                  className="btn" 
-                  type="submit" 
-                  disabled={isSubmitting} 
-                  style={{ 
+                <button
+                  className='btn'
+                  type='submit'
+                  disabled={isSubmitting}
+                  style={{
                     marginTop: '1.5em',
                     width: '100%',
                     maxWidth: '300px',

--- a/kor-react/src/components/shop/ShopDashboard.tsx
+++ b/kor-react/src/components/shop/ShopDashboard.tsx
@@ -404,8 +404,8 @@ const ShopDashboard: React.FC = () => {
     }
   }, [shopUser, getPlanFeatures]);
 
-  // Fetch live customer count using existing backend API (works during soft-auth too)
-  useEffect(() => {
+  // Function to fetch customer count (extracted for reusability)
+  const fetchCustomerCount = async () => {
     const shop_token = sessionStorage.getItem('shop_token');
     if (!shop_token) {
       console.log(
@@ -422,48 +422,51 @@ const ShopDashboard: React.FC = () => {
     setCustomerCountLoading(true);
     setCustomerCountError(null);
 
-    (async () => {
-      try {
-        const response = await fetch(`${baseUrl}/getShopUsers`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-          body: new URLSearchParams({
-            auth: authToken,
-            shop_token
-          }) as unknown as BodyInit,
-          redirect: 'follow' as RequestRedirect
-        });
+    try {
+      const response = await fetch(`${baseUrl}/getShopUsers`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: new URLSearchParams({
+          auth: authToken,
+          shop_token
+        }) as unknown as BodyInit,
+        redirect: 'follow' as RequestRedirect
+      });
 
-        if (!response.ok) {
-          const errText = await response.text().catch(() => '');
-          throw new Error(`HTTP ${response.status} ${errText}`);
-        }
-
-        const data = await response.json();
-        if (data && data.message === 'success') {
-          const count =
-            typeof data.user_count === 'number'
-              ? data.user_count
-              : Array.isArray(data.users)
-                ? data.users.length
-                : 0;
-          setCustomerCount(count);
-          console.log('👥 [ShopDashboard] Loaded customer count:', count);
-        } else {
-          throw new Error(data?.error || 'Failed to load user count');
-        }
-      } catch (err) {
-        console.error(
-          '❌ [ShopDashboard] Failed to fetch shop user count:',
-          err
-        );
-        setCustomerCountError(
-          err instanceof Error ? err.message : 'Unknown error'
-        );
-      } finally {
-        setCustomerCountLoading(false);
+      if (!response.ok) {
+        const errText = await response.text().catch(() => '');
+        throw new Error(`HTTP ${response.status} ${errText}`);
       }
-    })();
+
+      const data = await response.json();
+      if (data && data.message === 'success') {
+        const count =
+          typeof data.user_count === 'number'
+            ? data.user_count
+            : Array.isArray(data.users)
+              ? data.users.length
+              : 0;
+        setCustomerCount(count);
+        console.log('👥 [ShopDashboard] Loaded customer count:', count);
+      } else {
+        throw new Error(data?.error || 'Failed to load user count');
+      }
+    } catch (err) {
+      console.error(
+        '❌ [ShopDashboard] Failed to fetch shop user count:',
+        err
+      );
+      setCustomerCountError(
+        err instanceof Error ? err.message : 'Unknown error'
+      );
+    } finally {
+      setCustomerCountLoading(false);
+    }
+  };
+
+  // Fetch live customer count using existing backend API (works during soft-auth too)
+  useEffect(() => {
+    fetchCustomerCount();
   }, [isAuthenticated, shopUser?.shopCode]);
 
   // Allow the dashboard to render if we have session-based shop data, even while Auth0 initializes
@@ -630,6 +633,7 @@ const ShopDashboard: React.FC = () => {
         customerCount={customerCount}
         customerCountLoading={customerCountLoading}
         customerCountError={customerCountError}
+        onRefreshCustomerCount={fetchCustomerCount}
         params={params}
       />
 

--- a/kor-react/src/components/shop/ShopMaintenanceView.tsx
+++ b/kor-react/src/components/shop/ShopMaintenanceView.tsx
@@ -40,11 +40,14 @@ const ShopMaintenanceView: React.FC<ShopUsersAndBikesProps> = ({
     search,
     showAllParts,
     allBikesExpanded,
+    actionError,
+    removingUserIds,
     setSearch,
     toggleShowAllParts,
     fetchUsers,
     toggleExpand,
-    toggleAllBikes
+    toggleAllBikes,
+    removeUserFromShop,
   } = useShopMaintenance();
 
   // Local UI state (doesn't need to be in hook)
@@ -84,6 +87,13 @@ const ShopMaintenanceView: React.FC<ShopUsersAndBikesProps> = ({
         {/* Error State */}
         {error && <div style={errorStyle}>Error loading users: {error}</div>}
 
+        {/* Action Error State (e.g., failed remove) */}
+        {actionError && (
+          <div style={{ ...errorStyle, marginTop: error ? '0.5rem' : 0 }}>
+            {actionError}
+          </div>
+        )}
+
         {/* Empty State */}
         {!loading && !error && users.length === 0 && (
           <div style={emptyStateStyle}>No users found.</div>
@@ -112,6 +122,8 @@ const ShopMaintenanceView: React.FC<ShopUsersAndBikesProps> = ({
                   error: null,
                   expanded: false
                 };
+
+                const isRemoving = removingUserIds.has(user.strava_user_id);
 
                 return (
                   <UserCard

--- a/kor-react/src/components/shop/ShopMaintenanceView.tsx
+++ b/kor-react/src/components/shop/ShopMaintenanceView.tsx
@@ -1,6 +1,13 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+import { useAuth0 } from '@auth0/auth0-react';
 import { Loader2 } from 'lucide-react';
 import { useShopMaintenance } from './hooks/useShopMaintenance';
+import { fetchShopUsers, getApiConfig } from './services/shopMaintenanceApi';
+import { FAMILY_PLAN_EVENTS } from './constants/familyPlan';
+import {
+  getAdminUserId,
+  setAdminUserId as saveAdminUserId
+} from './utils/familyPlanAdmin';
 import {
   ShopUsersAndBikesProps,
   SortMode
@@ -32,8 +39,11 @@ const ShopMaintenanceView: React.FC<ShopUsersAndBikesProps> = ({
   showBikes = true
 }) => {
   // Get all state and actions from our custom hook
+  const { user: auth0User } = useAuth0();
+
   const {
     users,
+    allUsers,
     bikesByUser,
     loading,
     error,
@@ -41,17 +51,124 @@ const ShopMaintenanceView: React.FC<ShopUsersAndBikesProps> = ({
     showAllParts,
     allBikesExpanded,
     actionError,
-    removingUserIds,
     setSearch,
     toggleShowAllParts,
     fetchUsers,
     toggleExpand,
     toggleAllBikes,
-    removeUserFromShop,
   } = useShopMaintenance();
 
   // Local UI state (doesn't need to be in hook)
   const [sortMode, setSortMode] = useState<SortMode>('wear_desc');
+
+  const [adminUserId, setAdminUserId] = useState<number | null>(getAdminUserId);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const handleAdminUpdated = () => {
+      setAdminUserId(getAdminUserId());
+    };
+
+    window.addEventListener(FAMILY_PLAN_EVENTS.ADMIN_UPDATED, handleAdminUpdated);
+    return () => window.removeEventListener(FAMILY_PLAN_EVENTS.ADMIN_UPDATED, handleAdminUpdated);
+  }, []);
+
+  const auth0EmailRaw =
+    typeof auth0User?.email === 'string'
+      ? auth0User.email
+      : typeof (auth0User as any)?.name === 'string'
+        ? (auth0User as any).name
+        : null;
+
+  const auth0Email =
+    typeof auth0EmailRaw === 'string' && auth0EmailRaw.includes('@')
+      ? auth0EmailRaw
+      : null;
+
+  // Resolve the currently logged-in user's Strava user id.
+  // NOTE: Some endpoints may not include email; if so, we fall back to `getShopUsers`.
+  const [currentUserId, setCurrentUserId] = useState<number | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const resolveCurrentUserId = async () => {
+      if (!auth0Email) {
+        if (!cancelled) setCurrentUserId(null);
+        return;
+      }
+
+      // 1) Best case: maintenance report users include email
+      const directMatch = allUsers.find(
+        u => (u.email || '').toLowerCase() === auth0Email.toLowerCase()
+      );
+      if (directMatch?.strava_user_id != null) {
+        const parsed = Number((directMatch as any).strava_user_id);
+        if (!cancelled) setCurrentUserId(Number.isFinite(parsed) ? parsed : null);
+        return;
+      }
+
+      // 2) Fallback: fetch shop users list (includes email) to identify the viewer
+      try {
+        const config = getApiConfig();
+        const shopUsers = await fetchShopUsers(config);
+        const match = shopUsers.find(
+          (u: any) => (u?.email || '').toLowerCase() === auth0Email.toLowerCase()
+        );
+        const parsed = match?.strava_user_id != null ? Number(match.strava_user_id) : NaN;
+        if (!cancelled) setCurrentUserId(Number.isFinite(parsed) ? parsed : null);
+      } catch {
+        if (!cancelled) setCurrentUserId(null);
+      }
+    };
+
+    resolveCurrentUserId();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [allUsers, auth0Email]);
+
+  // If no admin has been selected yet, default to the current viewer.
+  // This ensures admin-only UI shows up immediately for the shop owner without requiring a modal selection.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (adminUserId != null) return;
+    if (currentUserId == null) return;
+
+    saveAdminUserId(currentUserId);
+    setAdminUserId(currentUserId);
+  }, [adminUserId, currentUserId]);
+
+  // Soft-auth fallback: if we cannot resolve the viewer's Strava id (Auth0 not hydrated / blocked),
+  // assume the viewer is the admin for UI labeling purposes.
+  const viewerIsAdmin =
+    adminUserId != null && (currentUserId == null || adminUserId === currentUserId);
+
+  // Final fallback: if no admin is selected and we have users loaded, default to the first user.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (adminUserId != null) return;
+    if (allUsers.length === 0) return;
+
+    const fallbackAdminId = Number((allUsers[0] as any).strava_user_id);
+    if (!Number.isFinite(fallbackAdminId)) return;
+
+    saveAdminUserId(fallbackAdminId);
+    setAdminUserId(fallbackAdminId);
+  }, [adminUserId, allUsers]);
+
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'development') return;
+    // eslint-disable-next-line no-console
+    console.debug('[ShopMaintenanceView] admin label state', {
+      auth0Email,
+      adminUserId,
+      currentUserId,
+      viewerIsAdmin,
+    });
+  }, [auth0Email, adminUserId, currentUserId, viewerIsAdmin]);
 
   /**
    * RENDERING: Clean and focused
@@ -109,6 +226,8 @@ const ShopMaintenanceView: React.FC<ShopUsersAndBikesProps> = ({
                 bikesByUser={bikesByUser}
                 showAllParts={showAllParts}
                 sortMode={sortMode}
+                adminUserId={adminUserId}
+                viewerIsAdmin={viewerIsAdmin}
               />
             </div>
 
@@ -123,7 +242,8 @@ const ShopMaintenanceView: React.FC<ShopUsersAndBikesProps> = ({
                   expanded: false
                 };
 
-                const isRemoving = removingUserIds.has(user.strava_user_id);
+                const isAdminUser = adminUserId != null && user.strava_user_id === adminUserId;
+                const showYou = viewerIsAdmin && isAdminUser;
 
                 return (
                   <UserCard
@@ -135,6 +255,7 @@ const ShopMaintenanceView: React.FC<ShopUsersAndBikesProps> = ({
                     readOnlyMode={readOnlyMode}
                     sortMode={sortMode}
                     onToggleExpand={toggleExpand}
+                    showYou={showYou}
                   />
                 );
               })}

--- a/kor-react/src/components/shop/WearBar/AllPartsWear.tsx
+++ b/kor-react/src/components/shop/WearBar/AllPartsWear.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useEffect } from 'react';
 import WearBar from './index';
 import { getWearPartsForBike } from './partWear';
 
@@ -18,6 +18,8 @@ interface AllPartsWearProps {
   showAllParts: boolean;
   // Controls how parts are sorted; currently we only use wear_desc (most worn -> least worn)
   sortMode?: 'wear_desc' | 'wear_asc';
+  adminUserId?: number | null;
+  viewerIsAdmin?: boolean;
 }
 
 interface PartEntry {
@@ -25,6 +27,7 @@ interface PartEntry {
   wearPercent: number;
   bikeName: string;
   ownerName: string;
+  ownerId: number;
   icon: string;
 }
 
@@ -32,9 +35,15 @@ const AllPartsWear: React.FC<AllPartsWearProps> = ({
   filteredUsers,
   bikesByUser,
   showAllParts,
-  sortMode = 'wear_desc'
+  sortMode = 'wear_desc',
+  adminUserId = null,
+  viewerIsAdmin = false,
 }) => {
   const [showAll, setShowAll] = React.useState(false);
+
+  useEffect(() => {
+    if (!showAllParts) setShowAll(false);
+  }, [showAllParts]);
 
   const allParts = useMemo(() => {
     if (!showAllParts) return [];
@@ -55,6 +64,7 @@ const AllPartsWear: React.FC<AllPartsWearProps> = ({
             wearPercent: part.wearPercent,
             bikeName,
             ownerName,
+            ownerId: user.strava_user_id,
             icon: part.icon
           });
         });
@@ -86,33 +96,69 @@ const AllPartsWear: React.FC<AllPartsWearProps> = ({
           background: '#fafafa'
         }}
       >
+        {/* Legend */}
+        {viewerIsAdmin && adminUserId != null && (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.5rem',
+              marginBottom: '1rem',
+              padding: '0.5rem 0.75rem',
+              background: '#f0f7ff',
+              borderRadius: 6,
+              fontSize: '0.875rem',
+              color: '#555'
+            }}
+          >
+            <div
+              style={{
+                width: 8,
+                height: 8,
+                borderRadius: '50%',
+                backgroundColor: '#3B82F6',
+                flexShrink: 0
+              }}
+            />
+            <span>Your parts</span>
+          </div>
+        )}
         <div
           style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}
         >
-          {visibleParts.map((part, index) => (
-            <div
-              key={`${part.ownerName}-${part.bikeName}-${part.label}-${index}`}
-            >
-              <WearBar
-                label={part.label}
-                value={part.wearPercent}
-                imageSRC={part.icon}
-              />
-              <div
-                style={{
-                  fontSize: '.9rem',
-                  color: '#555',
-                  marginLeft: '2rem',
-                  marginTop: '0.25rem'
-                }}
-              >
-                <span style={{ color: '#000', fontWeight: 600 }}>
-                  {part.bikeName}
-                </span>{' '}
-                (<span style={{ color: '#999' }}>{part.ownerName}</span>)
+          {visibleParts.map((part, index) => {
+            const isAdminOwner =
+              viewerIsAdmin &&
+              adminUserId != null &&
+              part.ownerId === adminUserId;
+
+            const label = part.label;
+            const ownerLabel = isAdminOwner ? 'You' : part.ownerName;
+
+            return (
+              <div key={`${part.ownerId}-${part.bikeName}-${part.label}-${index}`}>
+                <WearBar
+                  label={label}
+                  value={part.wearPercent}
+                  imageSRC={part.icon}
+                  showAdminIndicator={isAdminOwner}
+                />
+                <div
+                  style={{
+                    fontSize: '.9rem',
+                    color: '#555',
+                    marginLeft: '2rem',
+                    marginTop: '0.25rem'
+                  }}
+                >
+                  <span style={{ color: '#000', fontWeight: 600 }}>
+                    {part.bikeName}
+                  </span>{' '}
+                  (<span style={{ color: '#999' }}>{ownerLabel}</span>)
+                </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
         </div>
         {allParts.length > 5 && (
           <div

--- a/kor-react/src/components/shop/WearBar/index.tsx
+++ b/kor-react/src/components/shop/WearBar/index.tsx
@@ -6,13 +6,15 @@ interface WearBarProps {
   value: number;
   threshold?: number;
   imageSRC: string;
+  showAdminIndicator?: boolean;
 }
 
 const WearBar: React.FC<WearBarProps> = ({
   label,
   value,
   threshold = 75,
-  imageSRC
+  imageSRC,
+  showAdminIndicator = false
 }) => {
   // Determine bar color based on wear percentage
   let barColor = '#00FF75';
@@ -31,6 +33,19 @@ const WearBar: React.FC<WearBarProps> = ({
         mt: 1.5
       }}
     >
+      {/* Admin indicator */}
+      {showAdminIndicator && (
+        <Box
+          sx={{
+            width: 8,
+            height: 8,
+            mr: 0.75,
+            flexShrink: 0,
+            borderRadius: '50%',
+            backgroundColor: '#3B82F6'
+          }}
+        />
+      )}
       {/* Icon */}
       <Box sx={{ width: 28, height: 28, mr: 1, flexShrink: 0 }}>
         <img

--- a/kor-react/src/components/shop/components/ConfirmDeleteModal.tsx
+++ b/kor-react/src/components/shop/components/ConfirmDeleteModal.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import {
+  modalOverlayStyle,
+  confirmModalContentStyle,
+  confirmModalHeaderStyle,
+  confirmModalTextStyle,
+  confirmModalFooterStyle,
+  confirmButtonStyle,
+} from '../styles/userManagementModal.styles';
+
+interface ConfirmDeleteModalProps {
+  isOpen: boolean;
+  userName: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isDeleting: boolean;
+}
+
+const ConfirmDeleteModal: React.FC<ConfirmDeleteModalProps> = ({
+  isOpen,
+  userName,
+  onConfirm,
+  onCancel,
+  isDeleting
+}) => {
+  if (!isOpen) return null;
+
+  return (
+    <div style={modalOverlayStyle} onClick={onCancel}>
+      <div style={confirmModalContentStyle} onClick={(e) => e.stopPropagation()}>
+        <h3 style={confirmModalHeaderStyle}>Confirm Deletion</h3>
+        <p style={confirmModalTextStyle}>
+          Are you sure you want to remove <strong>{userName}</strong> from your family plan? This action cannot be undone.
+        </p>
+
+        <div style={confirmModalFooterStyle}>
+          <button
+            onClick={onCancel}
+            disabled={isDeleting}
+            style={confirmButtonStyle('cancel', isDeleting)}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={isDeleting}
+            style={confirmButtonStyle('danger', isDeleting)}
+          >
+            {isDeleting ? 'Deleting...' : 'Confirm'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmDeleteModal;

--- a/kor-react/src/components/shop/components/ConfirmDeleteModal.tsx
+++ b/kor-react/src/components/shop/components/ConfirmDeleteModal.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import {
+  modalOverlayStyle,
+  confirmModalContentStyle,
+  confirmModalHeaderStyle,
+  confirmModalTextStyle,
+  confirmModalFooterStyle,
+  confirmButtonStyle
+} from '../styles/userManagementModal.styles';
+
+interface ConfirmDeleteModalProps {
+  isOpen: boolean;
+  userName: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isDeleting: boolean;
+}
+
+const ConfirmDeleteModal: React.FC<ConfirmDeleteModalProps> = ({
+  isOpen,
+  userName,
+  onConfirm,
+  onCancel,
+  isDeleting
+}) => {
+  if (!isOpen) return null;
+
+  return (
+    <div style={modalOverlayStyle} onClick={onCancel}>
+      <div style={confirmModalContentStyle} onClick={e => e.stopPropagation()}>
+        <h3 style={confirmModalHeaderStyle}>Confirm Deletion</h3>
+        <p style={confirmModalTextStyle}>
+          Are you sure you want to remove <strong>{userName}</strong> from your
+          family plan? This action cannot be undone.
+        </p>
+
+        <div style={confirmModalFooterStyle}>
+          <button
+            onClick={onCancel}
+            disabled={isDeleting}
+            style={confirmButtonStyle('cancel', isDeleting)}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={isDeleting}
+            style={confirmButtonStyle('danger', isDeleting)}
+          >
+            {isDeleting ? 'Deleting...' : 'Confirm'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ConfirmDeleteModal;

--- a/kor-react/src/components/shop/components/ManageUsersModal.tsx
+++ b/kor-react/src/components/shop/components/ManageUsersModal.tsx
@@ -1,0 +1,182 @@
+import React, { useState, useEffect } from 'react';
+import { FamilyMember } from '../types/shopUsersAndBikes.types';
+import {
+  fetchShopUsers,
+  removeUserShop,
+  getApiConfig,
+  FetchConfig,
+} from '../services/shopMaintenanceApi';
+import ConfirmDeleteModal from './ConfirmDeleteModal';
+import {
+  modalOverlayStyle,
+  modalContentStyle,
+  modalHeaderStyle,
+  modalSubtextStyle,
+  userListContainerStyle,
+  userListItemStyle,
+  userListInfoStyle,
+  userListNameStyle,
+  userListEmailStyle,
+  deleteButtonStyle,
+  modalFooterStyle,
+  modalButtonStyle,
+  errorMessageStyle,
+  emptyStateStyle
+} from '../styles/userManagementModal.styles';
+
+interface ManageUsersModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onUserDeleted?: () => void;
+}
+
+const ManageUsersModal: React.FC<ManageUsersModalProps> = ({
+  isOpen,
+  onClose,
+  onUserDeleted
+}) => {
+  const [users, setUsers] = useState<FamilyMember[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedUser, setSelectedUser] = useState<FamilyMember | null>(null);
+  const [showConfirmModal, setShowConfirmModal] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      loadUsers();
+    }
+  }, [isOpen]);
+
+  const loadUsers = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const config: FetchConfig = getApiConfig();
+      const fetchedUsers = await fetchShopUsers(config);
+
+      // Transform users to FamilyMember format
+      const familyMembers: FamilyMember[] = fetchedUsers.map((user: any) => ({
+        id: user.strava_user_id,
+        first_name: user.first_name || '',
+        last_name: user.last_name || '',
+        email: user.email,
+        strava_user_id: user.strava_user_id
+      }));
+
+      setUsers(familyMembers);
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : 'Failed to load users';
+      setError(errorMessage);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDeleteClick = (user: FamilyMember) => {
+    setSelectedUser(user);
+    setShowConfirmModal(true);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!selectedUser) return;
+
+    setIsDeleting(true);
+    setError(null);
+    try {
+      const config: FetchConfig = getApiConfig();
+      await removeUserShop(config, selectedUser.id);
+
+      // Remove user from local state
+      setUsers(users.filter(u => u.id !== selectedUser.id));
+
+      // Close confirmation modal
+      setShowConfirmModal(false);
+      setSelectedUser(null);
+
+      // Notify parent component
+      onUserDeleted?.();
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : 'Failed to delete user';
+      setError(errorMessage);
+      setShowConfirmModal(false);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleCancelDelete = () => {
+    if (!isDeleting) {
+      setShowConfirmModal(false);
+      setSelectedUser(null);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const getUserDisplayName = (user: FamilyMember): string => {
+    const fullName = `${user.first_name} ${user.last_name}`.trim();
+    return fullName || user.email;
+  };
+
+  return (
+    <>
+      <div style={modalOverlayStyle} onClick={onClose}>
+        <div style={modalContentStyle} onClick={e => e.stopPropagation()}>
+          <h3 style={modalHeaderStyle}>Manage Family Members</h3>
+          <p style={modalSubtextStyle}>
+            Click the ✕ button next to a member's name to remove them from your
+            family plan.
+          </p>
+
+          {error && <div style={errorMessageStyle}>{error}</div>}
+
+          <div style={userListContainerStyle}>
+            {loading ? (
+              <div style={emptyStateStyle}>Loading users...</div>
+            ) : users.length === 0 ? (
+              <div style={emptyStateStyle}>No family members found</div>
+            ) : (
+              users.map(user => (
+                <div key={user.id} style={userListItemStyle}>
+                  <div style={userListInfoStyle}>
+                    <div style={userListNameStyle}>
+                      {getUserDisplayName(user)}
+                    </div>
+                    <div style={userListEmailStyle}>{user.email}</div>
+                  </div>
+                  <button
+                    style={deleteButtonStyle(isDeleting)}
+                    onClick={() => handleDeleteClick(user)}
+                    disabled={isDeleting}
+                    title='Remove user'
+                  >
+                    ✕
+                  </button>
+                </div>
+              ))
+            )}
+          </div>
+
+          <div style={modalFooterStyle}>
+            <button style={modalButtonStyle('secondary')} onClick={onClose}>
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <ConfirmDeleteModal
+        isOpen={showConfirmModal}
+        userName={selectedUser ? getUserDisplayName(selectedUser) : ''}
+        onConfirm={handleConfirmDelete}
+        onCancel={handleCancelDelete}
+        isDeleting={isDeleting}
+      />
+    </>
+  );
+};
+
+export default ManageUsersModal;

--- a/kor-react/src/components/shop/components/ManageUsersModal.tsx
+++ b/kor-react/src/components/shop/components/ManageUsersModal.tsx
@@ -1,23 +1,42 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
+import { useAuth0 } from '@auth0/auth0-react';
+import { Trash2, X, Shield } from 'lucide-react';
 import { FamilyMember } from '../types/shopUsersAndBikes.types';
 import {
   fetchShopUsers,
   removeUserShop,
+  setUserHead,
   getApiConfig,
-  FetchConfig,
+  FetchConfig
 } from '../services/shopMaintenanceApi';
+import {
+  getAdminUserId,
+  setAdminUserId as saveAdminUserId
+} from '../utils/familyPlanAdmin';
 import ConfirmDeleteModal from './ConfirmDeleteModal';
 import {
   modalOverlayStyle,
   modalContentStyle,
+  modalTitleRowStyle,
   modalHeaderStyle,
+  closeIconButtonStyle,
+  tabsContainerStyle,
+  tabButtonStyle,
+  tabPanelStyle,
   modalSubtextStyle,
   userListContainerStyle,
   userListItemStyle,
   userListInfoStyle,
+  userListNameRowStyle,
   userListNameStyle,
   userListEmailStyle,
+  adminBadgeStyle,
   deleteButtonStyle,
+  adminListContainerStyle,
+  adminListItemStyle,
+  adminRadioStyle,
+  adminRowRightStyle,
+  infoNoticeStyle,
   modalFooterStyle,
   modalButtonStyle,
   errorMessageStyle,
@@ -30,20 +49,38 @@ interface ManageUsersModalProps {
   onUserDeleted?: () => void;
 }
 
+type ManageUsersTab = 'family' | 'admin';
+
 const ManageUsersModal: React.FC<ManageUsersModalProps> = ({
   isOpen,
   onClose,
   onUserDeleted
 }) => {
+  const { user: auth0User } = useAuth0();
+
+  const [activeTab, setActiveTab] = useState<ManageUsersTab>('family');
   const [users, setUsers] = useState<FamilyMember[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedUser, setSelectedUser] = useState<FamilyMember | null>(null);
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isSavingAdmin, setIsSavingAdmin] = useState(false);
+
+  // Tracks the currently selected admin in the UI and persists to sessionStorage.
+  const [selectedAdminId, setSelectedAdminId] = useState<number | null>(null);
+  // Tracks the last successfully saved admin ID to detect changes.
+  const [savedAdminId, setSavedAdminId] = useState<number | null>(null);
 
   useEffect(() => {
     if (isOpen) {
+      setActiveTab('family');
+
+      // Restore current admin selection from sessionStorage.
+      const adminId = getAdminUserId();
+      setSelectedAdminId(adminId);
+      setSavedAdminId(adminId); // Track as saved to detect changes
+
       loadUsers();
     }
   }, [isOpen]);
@@ -89,7 +126,10 @@ const ManageUsersModal: React.FC<ManageUsersModalProps> = ({
       await removeUserShop(config, selectedUser.id);
 
       // Remove user from local state
-      setUsers(users.filter(u => u.id !== selectedUser.id));
+      setUsers(prev => prev.filter(u => u.id !== selectedUser.id));
+
+      // If the deleted user was selected as admin, clear the selection.
+      setSelectedAdminId(prev => (prev === selectedUser.id ? null : prev));
 
       // Close confirmation modal
       setShowConfirmModal(false);
@@ -114,6 +154,38 @@ const ManageUsersModal: React.FC<ManageUsersModalProps> = ({
     }
   };
 
+  /**
+   * Saves the selected admin to the backend API.
+   * Updates savedAdminId state on success.
+   */
+  const handleSaveAdmin = async () => {
+    if (selectedAdminId == null) {
+      setError('Please select a user to set as admin');
+      return;
+    }
+
+    setIsSavingAdmin(true);
+    setError(null);
+
+    try {
+      const config: FetchConfig = getApiConfig();
+      await setUserHead(config, selectedAdminId);
+
+      // Mark this selection as saved
+      setSavedAdminId(selectedAdminId);
+
+      // Persist to sessionStorage and notify listeners
+      saveAdminUserId(selectedAdminId);
+    } catch (err) {
+      const errorMessage =
+        err instanceof Error ? err.message : 'Failed to save admin selection';
+      setError(errorMessage);
+    } finally {
+      setIsSavingAdmin(false);
+    }
+  };
+
+
   if (!isOpen) return null;
 
   const getUserDisplayName = (user: FamilyMember): string => {
@@ -121,50 +193,199 @@ const ManageUsersModal: React.FC<ManageUsersModalProps> = ({
     return fullName || user.email;
   };
 
+  const auth0Email = typeof auth0User?.email === 'string' ? auth0User.email : null;
+
+  const isCurrentUser = (member: FamilyMember): boolean => {
+    if (!auth0Email) return false;
+    return member.email?.toLowerCase() === auth0Email.toLowerCase();
+  };
+
+  const getUserDisplayNameWithYou = (member: FamilyMember): string => {
+    const base = getUserDisplayName(member);
+    return selectedAdminId === member.id && isCurrentUser(member)
+      ? `${base} (You)`
+      : base;
+  };
+
+  const selectedAdminUser =
+    selectedAdminId == null
+      ? null
+      : (users.find(u => u.id === selectedAdminId) ?? null);
+
+  const selectedAdminDisplayName = selectedAdminUser
+    ? getUserDisplayNameWithYou(selectedAdminUser)
+    : null;
+
+  // Check if there are unsaved changes
+  const hasUnsavedChanges = selectedAdminId !== savedAdminId;
+
   return (
     <>
       <div style={modalOverlayStyle} onClick={onClose}>
         <div style={modalContentStyle} onClick={e => e.stopPropagation()}>
-          <h3 style={modalHeaderStyle}>Manage Family Members</h3>
-          <p style={modalSubtextStyle}>
-            Click the ✕ button next to a member's name to remove them from your
-            family plan.
-          </p>
+          <div style={modalTitleRowStyle}>
+            <h3 style={modalHeaderStyle}>Manage Users</h3>
+            <button
+              type='button'
+              onClick={onClose}
+              style={closeIconButtonStyle}
+              aria-label='Close'
+              title='Close'
+            >
+              <X size={18} />
+            </button>
+          </div>
+
+          <div style={tabsContainerStyle}>
+            <button
+              type='button'
+              onClick={() => setActiveTab('family')}
+              style={tabButtonStyle(activeTab === 'family')}
+            >
+              Family Members
+            </button>
+            <button
+              type='button'
+              onClick={() => setActiveTab('admin')}
+              style={tabButtonStyle(activeTab === 'admin')}
+            >
+              Admin Settings
+            </button>
+          </div>
 
           {error && <div style={errorMessageStyle}>{error}</div>}
 
-          <div style={userListContainerStyle}>
-            {loading ? (
-              <div style={emptyStateStyle}>Loading users...</div>
-            ) : users.length === 0 ? (
-              <div style={emptyStateStyle}>No family members found</div>
-            ) : (
-              users.map(user => (
-                <div key={user.id} style={userListItemStyle}>
-                  <div style={userListInfoStyle}>
-                    <div style={userListNameStyle}>
-                      {getUserDisplayName(user)}
-                    </div>
-                    <div style={userListEmailStyle}>{user.email}</div>
-                  </div>
-                  <button
-                    style={deleteButtonStyle(isDeleting)}
-                    onClick={() => handleDeleteClick(user)}
-                    disabled={isDeleting}
-                    title='Remove user'
-                  >
-                    ✕
-                  </button>
-                </div>
-              ))
-            )}
-          </div>
+          {activeTab === 'family' ? (
+            <div style={tabPanelStyle}>
+              <p style={modalSubtextStyle}>
+                Remove members from your family plan.
+              </p>
 
-          <div style={modalFooterStyle}>
-            <button style={modalButtonStyle('secondary')} onClick={onClose}>
-              Close
-            </button>
-          </div>
+              <div style={userListContainerStyle}>
+                {loading ? (
+                  <div style={emptyStateStyle}>Loading users...</div>
+                ) : users.length === 0 ? (
+                  <div style={emptyStateStyle}>No family members found</div>
+                ) : (
+                  users.map(user => (
+                    <div key={user.id} style={userListItemStyle}>
+                      <div style={userListInfoStyle}>
+                        <div style={userListNameRowStyle}>
+                          <div style={userListNameStyle}>
+                            {getUserDisplayNameWithYou(user)}
+                          </div>
+                          {selectedAdminId === user.id && (
+                            <span style={adminBadgeStyle}>
+                              <Shield size={14} /> Admin
+                            </span>
+                          )}
+                        </div>
+                        <div style={userListEmailStyle}>{user.email}</div>
+                      </div>
+                      <button
+                        type='button'
+                        style={deleteButtonStyle(isDeleting)}
+                        onClick={() => handleDeleteClick(user)}
+                        disabled={isDeleting}
+                        aria-label={`Remove ${getUserDisplayName(user)}`}
+                        title='Remove'
+                      >
+                        <Trash2 size={16} />
+                      </button>
+                    </div>
+                  ))
+                )}
+              </div>
+            </div>
+          ) : (
+            <div style={tabPanelStyle}>
+              <p style={modalSubtextStyle}>
+                Choose one family member to be the admin of the family plan.
+              </p>
+
+              {selectedAdminUser ? (
+                <div style={infoNoticeStyle}>
+                  Current admin: <strong>{selectedAdminDisplayName}</strong>
+                  {hasUnsavedChanges && (
+                    <span style={{ color: '#f39c12', marginLeft: '0.5rem' }}>
+                      (Unsaved changes)
+                    </span>
+                  )}
+                </div>
+              ) : (
+                <div style={infoNoticeStyle}>
+                  No admin selected
+                  {hasUnsavedChanges && (
+                    <span style={{ color: '#f39c12', marginLeft: '0.5rem' }}>
+                      (Unsaved changes)
+                    </span>
+                  )}
+                </div>
+              )}
+
+              <div style={adminListContainerStyle}>
+                {loading ? (
+                  <div style={emptyStateStyle}>Loading users...</div>
+                ) : users.length === 0 ? (
+                  <div style={emptyStateStyle}>No family members found</div>
+                ) : (
+                  users.map(user => (
+                    <label key={user.id} style={adminListItemStyle}>
+                      <input
+                        type='radio'
+                        name='family-plan-admin'
+                        checked={selectedAdminId === user.id}
+                        onChange={() => setSelectedAdminId(user.id)}
+                        style={adminRadioStyle}
+                      />
+                      <div style={{ minWidth: 0 }}>
+                        <div style={userListNameStyle}>{getUserDisplayNameWithYou(user)}</div>
+                        <div style={userListEmailStyle}>{user.email}</div>
+                      </div>
+                      <div style={adminRowRightStyle}>
+                        {selectedAdminId === user.id && (
+                          <span style={adminBadgeStyle}>
+                            <Shield size={14} /> Admin
+                          </span>
+                        )}
+                      </div>
+                    </label>
+                  ))
+                )}
+              </div>
+
+              <div style={{ ...modalFooterStyle, gap: '0.5rem' }}>
+                <button
+                  type='button'
+                  style={modalButtonStyle('secondary')}
+                  onClick={onClose}
+                  disabled={isSavingAdmin}
+                >
+                  Close
+                </button>
+                <button
+                  type='button'
+                  style={{
+                    ...modalButtonStyle('primary'),
+                    opacity: !hasUnsavedChanges || isSavingAdmin ? 0.6 : 1
+                  }}
+                  onClick={handleSaveAdmin}
+                  disabled={!hasUnsavedChanges || isSavingAdmin}
+                  title='Save admin selection'
+                >
+                  {isSavingAdmin ? 'Saving...' : 'Save'}
+                </button>
+              </div>
+            </div>
+          )}
+
+          {activeTab === 'family' && (
+            <div style={modalFooterStyle}>
+              <button type='button' style={modalButtonStyle('secondary')} onClick={onClose}>
+                Close
+              </button>
+            </div>
+          )}
         </div>
       </div>
 

--- a/kor-react/src/components/shop/components/ManageUsersModal.tsx
+++ b/kor-react/src/components/shop/components/ManageUsersModal.tsx
@@ -1,0 +1,179 @@
+import React, { useState, useEffect } from 'react';
+import { FamilyMember } from '../types/shopUsersAndBikes.types';
+import { fetchShopUsers, removeUserFromShop, getApiConfig } from '../services/shopMaintenanceApi';
+import ConfirmDeleteModal from './ConfirmDeleteModal';
+import {
+  modalOverlayStyle,
+  modalContentStyle,
+  modalHeaderStyle,
+  modalSubtextStyle,
+  userListContainerStyle,
+  userListItemStyle,
+  userListInfoStyle,
+  userListNameStyle,
+  userListEmailStyle,
+  deleteButtonStyle,
+  modalFooterStyle,
+  modalButtonStyle,
+  errorMessageStyle,
+  emptyStateStyle,
+} from '../styles/userManagementModal.styles';
+
+interface ManageUsersModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onUserDeleted?: () => void;
+}
+
+const ManageUsersModal: React.FC<ManageUsersModalProps> = ({
+  isOpen,
+  onClose,
+  onUserDeleted
+}) => {
+  const [users, setUsers] = useState<FamilyMember[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedUser, setSelectedUser] = useState<FamilyMember | null>(null);
+  const [showConfirmModal, setShowConfirmModal] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      loadUsers();
+    }
+  }, [isOpen]);
+
+  const loadUsers = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const config = getApiConfig();
+      const fetchedUsers = await fetchShopUsers(config);
+      
+      // Transform users to FamilyMember format
+      const familyMembers: FamilyMember[] = fetchedUsers.map((user: any) => ({
+        id: user.strava_user_id,
+        first_name: user.first_name || '',
+        last_name: user.last_name || '',
+        email: user.email,
+        strava_user_id: user.strava_user_id,
+      }));
+      
+      setUsers(familyMembers);
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to load users';
+      setError(errorMessage);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDeleteClick = (user: FamilyMember) => {
+    setSelectedUser(user);
+    setShowConfirmModal(true);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!selectedUser) return;
+
+    setIsDeleting(true);
+    setError(null);
+    try {
+      const config = getApiConfig();
+      await removeUserFromShop(config, selectedUser.id);
+      
+      // Remove user from local state
+      setUsers(users.filter(u => u.id !== selectedUser.id));
+      
+      // Close confirmation modal
+      setShowConfirmModal(false);
+      setSelectedUser(null);
+      
+      // Notify parent component
+      onUserDeleted?.();
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to delete user';
+      setError(errorMessage);
+      setShowConfirmModal(false);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleCancelDelete = () => {
+    if (!isDeleting) {
+      setShowConfirmModal(false);
+      setSelectedUser(null);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const getUserDisplayName = (user: FamilyMember): string => {
+    const fullName = `${user.first_name} ${user.last_name}`.trim();
+    return fullName || user.email;
+  };
+
+  return (
+    <>
+      <div style={modalOverlayStyle} onClick={onClose}>
+        <div style={modalContentStyle} onClick={(e) => e.stopPropagation()}>
+          <h3 style={modalHeaderStyle}>Manage Family Members</h3>
+          <p style={modalSubtextStyle}>
+            Click the ✕ button next to a member's name to remove them from your family plan.
+          </p>
+
+          {error && (
+            <div style={errorMessageStyle}>
+              {error}
+            </div>
+          )}
+
+          <div style={userListContainerStyle}>
+            {loading ? (
+              <div style={emptyStateStyle}>Loading users...</div>
+            ) : users.length === 0 ? (
+              <div style={emptyStateStyle}>No family members found</div>
+            ) : (
+              users.map((user) => (
+                <div key={user.id} style={userListItemStyle}>
+                  <div style={userListInfoStyle}>
+                    <div style={userListNameStyle}>{getUserDisplayName(user)}</div>
+                    <div style={userListEmailStyle}>{user.email}</div>
+                  </div>
+                  <button
+                    style={deleteButtonStyle(isDeleting)}
+                    onClick={() => handleDeleteClick(user)}
+                    disabled={isDeleting}
+                    title="Remove user"
+                  >
+                    ✕
+                  </button>
+                </div>
+              ))
+            )}
+          </div>
+
+          <div style={modalFooterStyle}>
+            <button
+              style={modalButtonStyle('secondary')}
+              onClick={onClose}
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <ConfirmDeleteModal
+        isOpen={showConfirmModal}
+        userName={selectedUser ? getUserDisplayName(selectedUser) : ''}
+        onConfirm={handleConfirmDelete}
+        onCancel={handleCancelDelete}
+        isDeleting={isDeleting}
+      />
+    </>
+  );
+};
+
+export default ManageUsersModal;

--- a/kor-react/src/components/shop/components/UserCard.tsx
+++ b/kor-react/src/components/shop/components/UserCard.tsx
@@ -21,6 +21,7 @@ import {
   userInfoStyle,
   avatarStyle,
   userNameStyle,
+  youSuffixStyle,
   userActionsStyle,
   statusBadgeStyle,
   statusDotStyle,
@@ -46,6 +47,7 @@ interface UserCardProps {
   readOnlyMode: boolean;
   sortMode: 'wear_desc' | 'wear_asc';
   onToggleExpand: (userId: number) => void;
+  showYou?: boolean;
 }
 
 /**
@@ -68,6 +70,7 @@ export const UserCard: React.FC<UserCardProps> = ({
   readOnlyMode,
   sortMode,
   onToggleExpand,
+  showYou = false,
 }) => {
   const fullName = getFullName(user.first_name, user.last_name);
   const initial = getInitial(fullName);
@@ -82,7 +85,10 @@ export const UserCard: React.FC<UserCardProps> = ({
         <div style={userInfoStyle}>
           <div style={avatarStyle(accentColor)}>{initial}</div>
           <div style={{ minWidth: 0, maxWidth: '100%' }}>
-            <div style={userNameStyle}>{fullName}</div>
+            <div style={userNameStyle}>
+              {fullName}
+              {showYou && <span style={youSuffixStyle}> (You)</span>}
+            </div>
           </div>
         </div>
 

--- a/kor-react/src/components/shop/constants/familyPlan.ts
+++ b/kor-react/src/components/shop/constants/familyPlan.ts
@@ -1,0 +1,13 @@
+/**
+ * Constants for Family Plan feature
+ * 
+ * Centralizing magic strings to avoid typos and make refactoring easier.
+ */
+
+export const FAMILY_PLAN_STORAGE_KEYS = {
+  ADMIN_ID: 'family_admin_id'
+} as const;
+
+export const FAMILY_PLAN_EVENTS = {
+  ADMIN_UPDATED: 'family-admin-updated'
+} as const;

--- a/kor-react/src/components/shop/hooks/usePlanFeatures.ts
+++ b/kor-react/src/components/shop/hooks/usePlanFeatures.ts
@@ -4,40 +4,62 @@ import { PlanFeatures } from '../types';
 export const usePlanFeatures = () => {
   const getPlanFeatures = useCallback((planType: string): PlanFeatures => {
     const plans: { [key: string]: PlanFeatures } = {
-      'basic': {
+      basic: {
         name: 'Basic Plan',
         maxCustomers: 50,
         maxNotifications: 100,
-        features: ['Customer Management', 'Basic Notifications', 'Email Support'],
+        features: [
+          'Customer Management',
+          'Basic Notifications',
+          'Email Support'
+        ],
         color: '#17a2b8',
         description: 'Perfect for small bike shops getting started with KOR'
       },
-      'premium': {
+      premium: {
         name: 'Premium Plan',
         maxCustomers: -1, // Unlimited customers
         maxNotifications: -1, // Unlimited notifications
-        features: ['Advanced Customer Management', 'Unlimited Notifications', 'Priority Support', 'Analytics Dashboard', 'Custom Campaigns'],
+        features: [
+          'Advanced Customer Management',
+          'Unlimited Notifications',
+          'Priority Support',
+          'Analytics Dashboard',
+          'Custom Campaigns'
+        ],
         color: '#28a745',
         description: 'Full-featured plan for growing bike shops'
       },
-      'pro': {
+      pro: {
         name: 'Pro Plan',
         maxCustomers: -1, // Unlimited customers
         maxNotifications: -1, // Unlimited notifications
-        features: ['Pro Customer Management', 'Unlimited Everything', '24/7 Support', 'Advanced Analytics', 'Custom Integrations'],
+        features: [
+          'Pro Customer Management',
+          'Unlimited Everything',
+          '24/7 Support',
+          'Advanced Analytics',
+          'Custom Integrations'
+        ],
         color: '#6f42c1',
         description: 'Complete solution for large bike shop networks'
-      }, 
-      'family': {
+      },
+      family: {
         name: 'Family Plan',
-        maxCustomers: 5, // Unlimited customers
+        maxCustomers: 6,
         maxNotifications: -1, // Unlimited notifications
-        features: ['Advanced Customer Management', 'Unlimited Notifications', 'Priority Support', 'Analytics Dashboard', 'Custom Campaigns'],
+        features: [
+          'Advanced Customer Management',
+          'Unlimited Notifications',
+          'Priority Support',
+          'Analytics Dashboard',
+          'Custom Campaigns'
+        ],
         color: '#BF4A00',
         description: 'The ideal solution for a family of up to 6 bikers'
-      },
+      }
     };
-    
+
     return plans[planType] || plans['basic'];
   }, []);
 

--- a/kor-react/src/components/shop/hooks/useShopMaintenance.ts
+++ b/kor-react/src/components/shop/hooks/useShopMaintenance.ts
@@ -12,7 +12,11 @@
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { MaintenanceUser, BikeState } from '../types/shopUsersAndBikes.types';
-import { fetchShopMaintenanceReports, getApiConfig } from '../services/shopMaintenanceApi';
+import {
+  fetchShopMaintenanceReports,
+  getApiConfig,
+  removeUserShop,
+} from '../services/shopMaintenanceApi';
 
 /**
  * Custom hook to manage shop maintenance data
@@ -33,9 +37,13 @@ export const useShopMaintenance = () => {
   // STATE: UI state
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
   const [showAllParts, setShowAllParts] = useState(false);
   const [allBikesExpanded, setAllBikesExpanded] = useState(false);
+  const [removingUserIds, setRemovingUserIds] = useState<Set<number>>(
+    () => new Set<number>()
+  );
 
   /**
    * USECALLBACK: Memoizes function to prevent unnecessary re-renders
@@ -44,6 +52,7 @@ export const useShopMaintenance = () => {
   const fetchUsers = useCallback(async () => {
     setLoading(true);
     setError(null);
+    setActionError(null);
     
     // Reset UI states when refreshing
     setShowAllParts(false);
@@ -118,6 +127,45 @@ export const useShopMaintenance = () => {
         [key]: { ...current, expanded: !current.expanded }
       };
     });
+  }, []);
+
+  /**
+   * Remove a user's association with this shop.
+   *
+   * This calls the backend /removeUserShop endpoint and, on success,
+   * removes the user from local state so the UI reflects the change.
+   */
+  const removeUserFromShop = useCallback(async (userId: number) => {
+    setActionError(null);
+    setRemovingUserIds(prev => {
+      const next = new Set(prev);
+      next.add(userId);
+      return next;
+    });
+
+    try {
+      const config = getApiConfig();
+
+      await removeUserShop(config, userId);
+
+      // Remove user and their bikes from local state
+      setUsers(prev => prev.filter(u => u.strava_user_id !== userId));
+      setBikesByUser(prev => {
+        const copy = { ...prev };
+        delete copy[String(userId)];
+        return copy;
+      });
+    } catch (e) {
+      setActionError(
+        e instanceof Error ? e.message : 'Failed to remove user from shop'
+      );
+    } finally {
+      setRemovingUserIds(prev => {
+        const next = new Set(prev);
+        next.delete(userId);
+        return next;
+      });
+    }
   }, []);
 
   /**
@@ -252,6 +300,10 @@ export const useShopMaintenance = () => {
     search,
     showAllParts,
     allBikesExpanded,
+
+    // Action state
+    actionError,
+    removingUserIds,
     
     // Actions (functions)
     setSearch,
@@ -260,5 +312,6 @@ export const useShopMaintenance = () => {
     fetchUsers,
     toggleExpand,
     toggleAllBikes,
+    removeUserFromShop,
   };
 };

--- a/kor-react/src/components/shop/hooks/useShopMaintenance.ts
+++ b/kor-react/src/components/shop/hooks/useShopMaintenance.ts
@@ -14,8 +14,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react';
 import { MaintenanceUser, BikeState } from '../types/shopUsersAndBikes.types';
 import {
   fetchShopMaintenanceReports,
-  getApiConfig,
-  removeUserShop,
+  getApiConfig
 } from '../services/shopMaintenanceApi';
 
 /**
@@ -31,7 +30,7 @@ import {
  */
 export const useShopMaintenance = () => {
   // STATE: Data storage
-  const [users, setUsers] = useState<MaintenanceUser[]>([]);
+  const [allUsers, setAllUsers] = useState<MaintenanceUser[]>([]);
   const [bikesByUser, setBikesByUser] = useState<Record<string, BikeState>>({});
   
   // STATE: UI state
@@ -41,9 +40,6 @@ export const useShopMaintenance = () => {
   const [search, setSearch] = useState('');
   const [showAllParts, setShowAllParts] = useState(false);
   const [allBikesExpanded, setAllBikesExpanded] = useState(false);
-  const [removingUserIds, setRemovingUserIds] = useState<Set<number>>(
-    () => new Set<number>()
-  );
 
   /**
    * USECALLBACK: Memoizes function to prevent unnecessary re-renders
@@ -70,17 +66,17 @@ export const useShopMaintenance = () => {
 
       // Map API response to our interface
       const mapped: MaintenanceUser[] = data.users.map((u: any) => ({
-        strava_user_id: u.strava_user_id,
+        strava_user_id: Number(u.strava_user_id),
         first_name: u.first_name,
         last_name: u.last_name,
         email: u.email,
         last_login: u.last_login,
         shop_activity: u.shop_activity,
-        bike_count: u.bike_count,
+        bike_count: Number(u.bike_count),
         bikes: u.bikes || []
       }));
 
-      setUsers(mapped);
+      setAllUsers(mapped);
 
       // Initialize bikes state - bikes already loaded from API
       const bikesState: Record<string, BikeState> = {};
@@ -129,44 +125,6 @@ export const useShopMaintenance = () => {
     });
   }, []);
 
-  /**
-   * Remove a user's association with this shop.
-   *
-   * This calls the backend /removeUserShop endpoint and, on success,
-   * removes the user from local state so the UI reflects the change.
-   */
-  const removeUserFromShop = useCallback(async (userId: number) => {
-    setActionError(null);
-    setRemovingUserIds(prev => {
-      const next = new Set(prev);
-      next.add(userId);
-      return next;
-    });
-
-    try {
-      const config = getApiConfig();
-
-      await removeUserShop(config, userId);
-
-      // Remove user and their bikes from local state
-      setUsers(prev => prev.filter(u => u.strava_user_id !== userId));
-      setBikesByUser(prev => {
-        const copy = { ...prev };
-        delete copy[String(userId)];
-        return copy;
-      });
-    } catch (e) {
-      setActionError(
-        e instanceof Error ? e.message : 'Failed to remove user from shop'
-      );
-    } finally {
-      setRemovingUserIds(prev => {
-        const next = new Set(prev);
-        next.delete(userId);
-        return next;
-      });
-    }
-  }, []);
 
   /**
    * Expand all bikes for all users
@@ -176,7 +134,7 @@ export const useShopMaintenance = () => {
     // Close All Parts view when expanding bikes
     setShowAllParts(false);
     
-    const ids = users.map(u => String(u.strava_user_id));
+    const ids = allUsers.map(u => String(u.strava_user_id));
     
     setBikesByUser(prev => {
       const copy = { ...prev };
@@ -192,13 +150,13 @@ export const useShopMaintenance = () => {
       return copy;
     });
     setAllBikesExpanded(true);
-  }, [users]);
+  }, [allUsers]);
 
   /**
    * Collapse all bikes for all users
    */
   const collapseAllBikes = useCallback(() => {
-    const ids = users.map(u => String(u.strava_user_id));
+    const ids = allUsers.map(u => String(u.strava_user_id));
     
     setBikesByUser(prev => {
       const copy = { ...prev };
@@ -211,7 +169,7 @@ export const useShopMaintenance = () => {
       return copy;
     });
     setAllBikesExpanded(false);
-  }, [users]);
+  }, [allUsers]);
 
   /**
    * Toggle between expand all / collapse all
@@ -232,9 +190,9 @@ export const useShopMaintenance = () => {
    */
   const filteredUsers = useMemo(() => {
     const term = search.trim().toLowerCase();
-    if (!term) return users;
+    if (!term) return allUsers;
 
-    return users.filter(u => {
+    return allUsers.filter(u => {
       // Search by user name
       const userName = `${u.first_name} ${u.last_name}`.toLowerCase();
       if (userName.includes(term)) return true;
@@ -253,9 +211,9 @@ export const useShopMaintenance = () => {
         'bottom bracket', 'brake', 'brake pad', 'brake rotor',
         'tire', 'fork', 'shock', 'sealant', 'dropper'
       ];
-      return partNames.some(part => part.includes(term) || term.includes(part));
+      return partNames.some(part => part.includes(term));
     });
-  }, [users, search, bikesByUser]);
+  }, [allUsers, search, bikesByUser]);
 
   /**
    * Toggle Show All Parts view
@@ -269,7 +227,7 @@ export const useShopMaintenance = () => {
     if (newShowAllParts && allBikesExpanded) {
       setAllBikesExpanded(false);
       // Collapse all individual bike expansions too
-      const ids = users.map(u => String(u.strava_user_id));
+      const ids = allUsers.map(u => String(u.strava_user_id));
       setBikesByUser(prev => {
         const copy = { ...prev };
         ids.forEach(id => {
@@ -280,7 +238,7 @@ export const useShopMaintenance = () => {
         return copy;
       });
     }
-  }, [showAllParts, allBikesExpanded, users]);
+  }, [showAllParts, allBikesExpanded, allUsers]);
 
   /**
    * RETURN: Expose state and actions to component
@@ -290,6 +248,7 @@ export const useShopMaintenance = () => {
   return {
     // Data
     users: filteredUsers,
+    allUsers,
     bikesByUser,
     
     // Loading states
@@ -303,7 +262,6 @@ export const useShopMaintenance = () => {
 
     // Action state
     actionError,
-    removingUserIds,
     
     // Actions (functions)
     setSearch,
@@ -311,7 +269,6 @@ export const useShopMaintenance = () => {
     toggleShowAllParts,
     fetchUsers,
     toggleExpand,
-    toggleAllBikes,
-    removeUserFromShop,
+    toggleAllBikes
   };
 };

--- a/kor-react/src/components/shop/modules/PlanSpecificModules.tsx
+++ b/kor-react/src/components/shop/modules/PlanSpecificModules.tsx
@@ -20,6 +20,7 @@ interface PlanSpecificModulesProps
     CustomerUsageProps {
   planType: string;
   params: any; // For accessing URL params
+  onRefreshCustomerCount?: () => void;
 }
 
 const PlanSpecificModules: React.FC<PlanSpecificModulesProps> = ({
@@ -29,6 +30,7 @@ const PlanSpecificModules: React.FC<PlanSpecificModulesProps> = ({
   customerCount,
   customerCountLoading,
   customerCountError,
+  onRefreshCustomerCount,
   params
 }) => {
   const normalizedPlanType = planType.toLowerCase();
@@ -131,6 +133,7 @@ const PlanSpecificModules: React.FC<PlanSpecificModulesProps> = ({
               customerCount={customerCount}
               customerCountLoading={customerCountLoading}
               customerCountError={customerCountError}
+              onUserDeleted={onRefreshCustomerCount}
             />
 
             {/* Subscription details */}

--- a/kor-react/src/components/shop/sections/FamilyPlanUsage.tsx
+++ b/kor-react/src/components/shop/sections/FamilyPlanUsage.tsx
@@ -1,16 +1,38 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { DashboardSectionProps, CustomerUsageProps } from '../types';
+import ManageUsersModal from '../components/ManageUsersModal';
 
 interface FamilyPlanUsageProps
   extends DashboardSectionProps,
-    CustomerUsageProps {}
+    CustomerUsageProps {
+  onUserDeleted?: () => void;
+}
 
 const FamilyPlanUsage: React.FC<FamilyPlanUsageProps> = ({
   planFeatures,
   customerCount,
   customerCountLoading,
-  customerCountError
+  customerCountError,
+  onUserDeleted,
 }) => {
+  const [showManageUsersModal, setShowManageUsersModal] = useState(false);
+
+  // Local copy of count so the bar updates immediately when a user is removed.
+  const [effectiveCount, setEffectiveCount] = useState<number>(customerCount ?? 0);
+
+  // Keep local count in sync with latest value from parent when it changes.
+  useEffect(() => {
+    if (typeof customerCount === 'number') {
+      setEffectiveCount(customerCount);
+    }
+  }, [customerCount]);
+
+  const handleUserDeleted = () => {
+    // Update local count immediately so the bar and label reflect the change.
+    setEffectiveCount(prev => Math.max(0, prev - 1));
+    // Notify parent to refresh data (e.g., re-fetch counts from backend)
+    onUserDeleted?.();
+  };
   return (
     <div
       style={{
@@ -59,7 +81,7 @@ const FamilyPlanUsage: React.FC<FamilyPlanUsageProps> = ({
               <strong>Family Members</strong>
 
               <span>
-                {customerCountLoading ? 'Loading…' : (customerCount ?? 0)} /{' '}
+                {customerCountLoading ? 'Loading…' : effectiveCount} /{' '}
                 {planFeatures?.maxCustomers === -1
                   ? '∞'
                   : planFeatures?.maxCustomers}
@@ -93,7 +115,7 @@ const FamilyPlanUsage: React.FC<FamilyPlanUsageProps> = ({
                           ? Math.min(
                               100,
                               Math.round(
-                                ((customerCount ?? 0) /
+                                (effectiveCount /
                                   planFeatures.maxCustomers) *
                                   100
                               )
@@ -105,7 +127,35 @@ const FamilyPlanUsage: React.FC<FamilyPlanUsageProps> = ({
                 </div>
               </div>
             )}
-
+            {/* Manage Users Button */}
+            <div
+              style={{
+                maxWidth: '700px',
+                width: '100%',
+                margin: '1rem auto 0.5rem',
+                display: 'flex',
+                justifyContent: 'center'
+              }}
+            >
+              <button
+                onClick={() => setShowManageUsersModal(true)}
+                style={{
+                  backgroundColor: planFeatures?.color || '#007bff',
+                  color: 'white',
+                  border: 'none',
+                  padding: '0.6rem 1.2rem',
+                  borderRadius: '6px',
+                  cursor: 'pointer',
+                  fontSize: '0.95rem',
+                  fontWeight: 500,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '0.5rem'
+                }}
+              >
+                👥 Manage Users
+              </button>
+            </div>
             {customerCountError && (
               <p
                 style={{
@@ -120,6 +170,13 @@ const FamilyPlanUsage: React.FC<FamilyPlanUsageProps> = ({
           </div>
         </div>
       </div>
+
+      {/* Manage Users Modal */}
+      <ManageUsersModal
+        isOpen={showManageUsersModal}
+        onClose={() => setShowManageUsersModal(false)}
+        onUserDeleted={handleUserDeleted}
+      />
     </div>
   );
 };

--- a/kor-react/src/components/shop/sections/FamilyPlanUsage.tsx
+++ b/kor-react/src/components/shop/sections/FamilyPlanUsage.tsx
@@ -1,16 +1,26 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { DashboardSectionProps, CustomerUsageProps } from '../types';
+import ManageUsersModal from '../components/ManageUsersModal';
 
 interface FamilyPlanUsageProps
   extends DashboardSectionProps,
-    CustomerUsageProps {}
+    CustomerUsageProps {
+  onUserDeleted?: () => void;
+}
 
 const FamilyPlanUsage: React.FC<FamilyPlanUsageProps> = ({
   planFeatures,
   customerCount,
   customerCountLoading,
-  customerCountError
+  customerCountError,
+  onUserDeleted
 }) => {
+  const [showManageUsersModal, setShowManageUsersModal] = useState(false);
+
+  const handleUserDeleted = () => {
+    // Notify parent to refresh data
+    onUserDeleted?.();
+  };
   return (
     <div
       style={{
@@ -105,7 +115,35 @@ const FamilyPlanUsage: React.FC<FamilyPlanUsageProps> = ({
                 </div>
               </div>
             )}
-
+            {/* Manage Users Button */}
+            <div
+              style={{
+                maxWidth: '700px',
+                width: '100%',
+                margin: '1rem auto 0.5rem',
+                display: 'flex',
+                justifyContent: 'center'
+              }}
+            >
+              <button
+                onClick={() => setShowManageUsersModal(true)}
+                style={{
+                  backgroundColor: planFeatures?.color || '#007bff',
+                  color: 'white',
+                  border: 'none',
+                  padding: '0.6rem 1.2rem',
+                  borderRadius: '6px',
+                  cursor: 'pointer',
+                  fontSize: '0.95rem',
+                  fontWeight: 500,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '0.5rem'
+                }}
+              >
+                👥 Manage Users
+              </button>
+            </div>
             {customerCountError && (
               <p
                 style={{
@@ -120,6 +158,13 @@ const FamilyPlanUsage: React.FC<FamilyPlanUsageProps> = ({
           </div>
         </div>
       </div>
+
+      {/* Manage Users Modal */}
+      <ManageUsersModal
+        isOpen={showManageUsersModal}
+        onClose={() => setShowManageUsersModal(false)}
+        onUserDeleted={handleUserDeleted}
+      />
     </div>
   );
 };

--- a/kor-react/src/components/shop/sections/FamilyPlanUsage.tsx
+++ b/kor-react/src/components/shop/sections/FamilyPlanUsage.tsx
@@ -13,12 +13,14 @@ const FamilyPlanUsage: React.FC<FamilyPlanUsageProps> = ({
   customerCount,
   customerCountLoading,
   customerCountError,
-  onUserDeleted,
+  onUserDeleted
 }) => {
   const [showManageUsersModal, setShowManageUsersModal] = useState(false);
 
   // Local copy of count so the bar updates immediately when a user is removed.
-  const [effectiveCount, setEffectiveCount] = useState<number>(customerCount ?? 0);
+  const [effectiveCount, setEffectiveCount] = useState<number>(
+    customerCount ?? 0
+  );
 
   // Keep local count in sync with latest value from parent when it changes.
   useEffect(() => {
@@ -115,8 +117,7 @@ const FamilyPlanUsage: React.FC<FamilyPlanUsageProps> = ({
                           ? Math.min(
                               100,
                               Math.round(
-                                (effectiveCount /
-                                  planFeatures.maxCustomers) *
+                                (effectiveCount / planFeatures.maxCustomers) *
                                   100
                               )
                             )
@@ -153,7 +154,7 @@ const FamilyPlanUsage: React.FC<FamilyPlanUsageProps> = ({
                   gap: '0.5rem'
                 }}
               >
-                👥 Manage Users
+                Manage Users
               </button>
             </div>
             {customerCountError && (

--- a/kor-react/src/components/shop/services/shopMaintenanceApi.ts
+++ b/kor-react/src/components/shop/services/shopMaintenanceApi.ts
@@ -11,13 +11,13 @@
 
 import { convertApiResponse } from '../modules/dataConverter';
 
-interface FetchConfig {
+export interface FetchConfig {
   baseUrl: string;
   authToken: string;
   shopToken: string;
 }
 
-interface ShopMaintenanceResponse {
+export interface ShopMaintenanceResponse {
   message: string;
   shop_info: {
     shop_name: string;
@@ -31,6 +31,13 @@ interface ShopMaintenanceResponse {
     has_more: boolean;
   };
   users: any[];
+}
+
+export interface RemoveUserShopResponse {
+  message: string;
+  strava_user_id: number | string;
+  previous_shop_token?: string | null;
+  updated: number;
 }
 
 /**
@@ -67,6 +74,82 @@ export const fetchShopMaintenanceReports = async (
 
   // Convert API response to proper format (handles 0/1 to boolean conversion)
   return convertApiResponse(data);
+};
+
+/**
+ * Fetches basic shop users list (without maintenance details).
+ * Used by the family plan Manage Users modal.
+ */
+export const fetchShopUsers = async (
+  config: FetchConfig
+): Promise<any[]> => {
+  const { baseUrl, authToken, shopToken } = config;
+
+  if (!shopToken) {
+    throw new Error('Missing shop_token. Please log in again.');
+  }
+
+  const response = await fetch(`${baseUrl}/getShopUsers`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      auth: authToken,
+      shop_token: shopToken,
+    }) as unknown as BodyInit,
+    redirect: 'follow' as RequestRedirect,
+  });
+
+  if (!response.ok) {
+    const errText = await response.text().catch(() => '');
+    throw new Error(`Failed to load users (HTTP ${response.status} ${errText})`);
+  }
+
+  const data = await response.json();
+
+  if (data?.message !== 'success' || !Array.isArray(data?.users)) {
+    throw new Error(data?.error || 'Unexpected response when loading users');
+  }
+
+  return data.users;
+};
+
+/**
+ * Removes a user's association with the current shop.
+ *
+ * NOTE: This endpoint does not require auth or shop_token; it only
+ * needs the Strava user id. We still use the shared baseUrl from config
+ * to keep API configuration centralized.
+ */
+export const removeUserShop = async (
+  config: FetchConfig,
+  stravaUserId: number | string
+): Promise<RemoveUserShopResponse> => {
+  const { baseUrl } = config;
+  const response = await fetch(`${baseUrl}/removeUserShop`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      strava_user_id: String(stravaUserId)
+    }) as unknown as BodyInit,
+    redirect: 'follow' as RequestRedirect
+  });
+
+  if (!response.ok) {
+    const errText = await response.text().catch(() => '');
+    throw new Error(
+      `Failed to remove user from shop (HTTP ${response.status} ${errText})`
+    );
+  }
+
+  const data = (await response.json()) as RemoveUserShopResponse & {
+    error?: string;
+  };
+
+  if (data?.message !== 'success') {
+    throw new Error(data?.error || data?.message || 'Failed to remove user');
+  }
+
+  return data;
 };
 
 /**

--- a/kor-react/src/components/shop/services/shopMaintenanceApi.ts
+++ b/kor-react/src/components/shop/services/shopMaintenanceApi.ts
@@ -40,6 +40,11 @@ export interface RemoveUserShopResponse {
   updated: number;
 }
 
+export interface SetUserHeadResponse {
+  message: string;
+  strava_user_id: number | string;
+}
+
 /**
  * Fetches all shop users with their bikes and maintenance data
  *
@@ -153,60 +158,57 @@ export const removeUserShop = async (
 };
 
 /**
+ * Sets a user as the head/admin of the family plan.
+ *
+ * @param config - API configuration (baseUrl is used)
+ * @param stravaUserId - Strava user ID of the user to set as admin
+ * @returns Response indicating success
+ * @throws Error if API call fails
+ */
+export const setUserHead = async (
+  config: FetchConfig,
+  stravaUserId: number | string
+): Promise<SetUserHeadResponse> => {
+  const { baseUrl } = config;
+
+  const response = await fetch(`${baseUrl}/setUserHead`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      strava_user_id: String(stravaUserId)
+    }) as unknown as BodyInit,
+    redirect: 'follow' as RequestRedirect
+  });
+
+  if (!response.ok) {
+    const errText = await response.text().catch(() => '');
+    throw new Error(
+      `Failed to set user as admin (HTTP ${response.status} ${errText})`
+    );
+  }
+
+  const data = (await response.json()) as SetUserHeadResponse & {
+    error?: string;
+  };
+
+  if (data?.message !== 'success') {
+    throw new Error(data?.error || data?.message || 'Failed to set user as admin');
+  }
+
+  return data;
+};
+
+/**
  * Gets API configuration from environment and session storage
  */
 export const getApiConfig = (): FetchConfig => {
   const baseUrl =
     process.env.REACT_APP_API_BASE_URL || 'https://jmrcycling.com:3001';
-  const authToken =
-    process.env.REACT_APP_API_AUTH_TOKEN || '1893784827439273928203838';
+  const authToken = process.env.REACT_APP_API_AUTH_TOKEN || '';
   const shopToken =
     typeof window !== 'undefined'
       ? sessionStorage.getItem('shop_token') || ''
       : '';
 
   return { baseUrl, authToken, shopToken };
-};
-
-
-/**
- * Removes a user from the bike shop (stub for now)
- *
- * @param config - API configuration
- * @param userId - ID of the user to remove
- * @throws Error if API call fails
- */
-export const removeUserFromShop = async (
-  config: FetchConfig,
-  userId: number
-): Promise<void> => {
-  // TODO: Replace with actual API endpoint when backend is ready
-  const stubUrl = '/api/remove-user-from-shop';
-  
-  console.log(`Stub API call to ${stubUrl} for user ID:`, userId);
-  
-  // Simulate API delay
-  await new Promise(resolve => setTimeout(resolve, 1000));
-  
-  // When the real endpoint is ready, use this pattern:
-  // const { baseUrl, authToken, shopToken } = config;
-  // const response = await fetch(`${baseUrl}/removeShopUser`, {
-  //   method: 'POST',
-  //   headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-  //   body: new URLSearchParams({
-  //     auth: authToken,
-  //     shop_token: shopToken,
-  //     user_id: userId.toString()
-  //   }) as unknown as BodyInit,
-  //   redirect: 'follow' as RequestRedirect
-  // });
-  //
-  // if (!response.ok) {
-  //   throw new Error(`HTTP ${response.status}`);
-  // }
-  //
-  // const data = await response.json();
-  // if (data?.message !== 'success') {
-  //   throw new Error(data?.error || 'Failed to remove user');
-  // }
 };

--- a/kor-react/src/components/shop/services/shopMaintenanceApi.ts
+++ b/kor-react/src/components/shop/services/shopMaintenanceApi.ts
@@ -168,40 +168,6 @@ export const getApiConfig = (): FetchConfig => {
   return { baseUrl, authToken, shopToken };
 };
 
-/**
- * Fetches shop users for family plan management
- *
- * @param config - API configuration (baseUrl, authToken, shopToken)
- * @returns List of family members
- * @throws Error if API call fails or returns invalid data
- */
-export const fetchShopUsers = async (
-  config: FetchConfig
-): Promise<any[]> => {
-  const { baseUrl, authToken, shopToken } = config;
-
-  const response = await fetch(`${baseUrl}/getShopUsers`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      auth: authToken,
-      shop_token: shopToken
-    }) as unknown as BodyInit,
-    redirect: 'follow' as RequestRedirect
-  });
-
-  if (!response.ok) {
-    throw new Error(`HTTP ${response.status}`);
-  }
-
-  const data = await response.json();
-
-  if (data?.message !== 'success') {
-    throw new Error(data?.error || 'Failed to load users');
-  }
-
-  return data.users || [];
-};
 
 /**
  * Removes a user from the bike shop (stub for now)

--- a/kor-react/src/components/shop/services/shopMaintenanceApi.ts
+++ b/kor-react/src/components/shop/services/shopMaintenanceApi.ts
@@ -84,3 +84,80 @@ export const getApiConfig = (): FetchConfig => {
 
   return { baseUrl, authToken, shopToken };
 };
+
+/**
+ * Fetches shop users for family plan management
+ *
+ * @param config - API configuration (baseUrl, authToken, shopToken)
+ * @returns List of family members
+ * @throws Error if API call fails or returns invalid data
+ */
+export const fetchShopUsers = async (
+  config: FetchConfig
+): Promise<any[]> => {
+  const { baseUrl, authToken, shopToken } = config;
+
+  const response = await fetch(`${baseUrl}/getShopUsers`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      auth: authToken,
+      shop_token: shopToken
+    }) as unknown as BodyInit,
+    redirect: 'follow' as RequestRedirect
+  });
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+
+  const data = await response.json();
+
+  if (data?.message !== 'success') {
+    throw new Error(data?.error || 'Failed to load users');
+  }
+
+  return data.users || [];
+};
+
+/**
+ * Removes a user from the bike shop (stub for now)
+ *
+ * @param config - API configuration
+ * @param userId - ID of the user to remove
+ * @throws Error if API call fails
+ */
+export const removeUserFromShop = async (
+  config: FetchConfig,
+  userId: number
+): Promise<void> => {
+  // TODO: Replace with actual API endpoint when backend is ready
+  const stubUrl = '/api/remove-user-from-shop';
+  
+  console.log(`Stub API call to ${stubUrl} for user ID:`, userId);
+  
+  // Simulate API delay
+  await new Promise(resolve => setTimeout(resolve, 1000));
+  
+  // When the real endpoint is ready, use this pattern:
+  // const { baseUrl, authToken, shopToken } = config;
+  // const response = await fetch(`${baseUrl}/removeShopUser`, {
+  //   method: 'POST',
+  //   headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+  //   body: new URLSearchParams({
+  //     auth: authToken,
+  //     shop_token: shopToken,
+  //     user_id: userId.toString()
+  //   }) as unknown as BodyInit,
+  //   redirect: 'follow' as RequestRedirect
+  // });
+  //
+  // if (!response.ok) {
+  //   throw new Error(`HTTP ${response.status}`);
+  // }
+  //
+  // const data = await response.json();
+  // if (data?.message !== 'success') {
+  //   throw new Error(data?.error || 'Failed to remove user');
+  // }
+};

--- a/kor-react/src/components/shop/styles/shopMaintenance.styles.ts
+++ b/kor-react/src/components/shop/styles/shopMaintenance.styles.ts
@@ -194,6 +194,11 @@ export const userNameStyle: CSSProperties = {
   whiteSpace: 'nowrap',
 };
 
+export const youSuffixStyle: CSSProperties = {
+  fontWeight: 600,
+  color: tokens.colors.textSecondary,
+};
+
 export const userActionsStyle: CSSProperties = {
   display: 'flex',
   alignItems: 'center',

--- a/kor-react/src/components/shop/styles/userManagementModal.styles.ts
+++ b/kor-react/src/components/shop/styles/userManagementModal.styles.ts
@@ -1,0 +1,194 @@
+/**
+ * Styles for User Management Modals
+ * Used for managing family plan users (viewing, deleting)
+ */
+
+import { CSSProperties } from 'react';
+import { tokens } from './shopMaintenance.styles';
+
+export const modalOverlayStyle: CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(0,0,0,0.6)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 9999,
+};
+
+export const modalContentStyle: CSSProperties = {
+  background: 'white',
+  padding: '1.5rem',
+  width: '100%',
+  maxWidth: '600px',
+  maxHeight: '80vh',
+  borderRadius: '8px',
+  boxShadow: '0 10px 20px rgba(0,0,0,0.3)',
+  display: 'flex',
+  flexDirection: 'column',
+};
+
+export const modalHeaderStyle: CSSProperties = {
+  marginTop: 0,
+  color: tokens.colors.textPrimary,
+  marginBottom: '1rem',
+  fontSize: '1.5rem',
+};
+
+export const modalSubtextStyle: CSSProperties = {
+  color: tokens.colors.textSecondary,
+  marginBottom: '1rem',
+  fontSize: '0.9rem',
+};
+
+export const userListContainerStyle: CSSProperties = {
+  flex: '1 1 auto',
+  overflowY: 'auto',
+  marginBottom: '1rem',
+};
+
+export const userListItemStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '0.75rem',
+  border: `1px solid ${tokens.colors.border}`,
+  borderRadius: tokens.borderRadius.sm,
+  marginBottom: '0.5rem',
+  background: tokens.colors.white,
+};
+
+export const userListInfoStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  flex: 1,
+  minWidth: 0,
+};
+
+export const userListNameStyle: CSSProperties = {
+  fontWeight: 600,
+  color: tokens.colors.textPrimary,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+};
+
+export const userListEmailStyle: CSSProperties = {
+  fontSize: '0.85rem',
+  color: tokens.colors.textSecondary,
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+};
+
+export const deleteButtonStyle = (disabled: boolean): CSSProperties => ({
+  backgroundColor: '#d63031',
+  color: 'white',
+  border: 'none',
+  padding: '0.4rem 0.6rem',
+  borderRadius: '4px',
+  cursor: disabled ? 'not-allowed' : 'pointer',
+  fontSize: '1.2rem',
+  opacity: disabled ? 0.5 : 1,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  minWidth: '32px',
+  minHeight: '32px',
+});
+
+export const modalFooterStyle: CSSProperties = {
+  display: 'flex',
+  justifyContent: 'flex-end',
+  gap: '0.75rem',
+  paddingTop: '1rem',
+  borderTop: `1px solid ${tokens.colors.border}`,
+};
+
+export const modalButtonStyle = (
+  variant: 'primary' | 'secondary'
+): CSSProperties => ({
+  backgroundColor: variant === 'primary' ? '#007bff' : '#f8f9fa',
+  color: variant === 'primary' ? 'white' : '#495057',
+  border: variant === 'secondary' ? `1px solid ${tokens.colors.border}` : 'none',
+  padding: '0.5rem 1rem',
+  borderRadius: '4px',
+  cursor: 'pointer',
+  fontSize: '0.95rem',
+  fontWeight: 500,
+});
+
+// Confirmation modal styles
+export const confirmModalContentStyle: CSSProperties = {
+  ...modalContentStyle,
+  maxWidth: '400px',
+};
+
+export const confirmModalHeaderStyle: CSSProperties = {
+  marginTop: 0,
+  color: '#d63031',
+  marginBottom: '0.5rem',
+  fontSize: '1.25rem',
+};
+
+export const confirmModalTextStyle: CSSProperties = {
+  color: tokens.colors.textSecondary,
+  marginBottom: '1.5rem',
+  lineHeight: '1.5',
+};
+
+export const confirmModalFooterStyle: CSSProperties = {
+  display: 'flex',
+  justifyContent: 'flex-end',
+  gap: '0.75rem',
+};
+
+export const confirmButtonStyle = (
+  variant: 'danger' | 'cancel',
+  disabled: boolean
+): CSSProperties => ({
+  backgroundColor: variant === 'danger' ? '#d63031' : '#f8f9fa',
+  color: variant === 'danger' ? 'white' : '#495057',
+  border: variant === 'cancel' ? `1px solid ${tokens.colors.border}` : 'none',
+  padding: '0.5rem 1rem',
+  borderRadius: '4px',
+  cursor: disabled ? 'not-allowed' : 'pointer',
+  opacity: disabled ? 0.6 : 1,
+  fontSize: '0.95rem',
+  fontWeight: 500,
+});
+
+export const loadingSpinnerStyle: CSSProperties = {
+  display: 'inline-block',
+  width: '14px',
+  height: '14px',
+  border: '2px solid rgba(255,255,255,0.3)',
+  borderTop: '2px solid white',
+  borderRadius: '50%',
+  animation: 'spin 0.8s linear infinite',
+  marginRight: '0.5rem',
+};
+
+export const errorMessageStyle: CSSProperties = {
+  backgroundColor: '#ffe6e6',
+  color: '#d63031',
+  padding: '0.75rem',
+  borderRadius: '6px',
+  border: '1px solid #d63031',
+  marginBottom: '1rem',
+  fontSize: '0.9rem',
+};
+
+export const emptyStateStyle: CSSProperties = {
+  textAlign: 'center',
+  padding: '2rem',
+  color: tokens.colors.textSecondary,
+};
+
+// CSS animation string for injecting into a <style> tag if needed
+export const spinAnimationCSS = `
+  @keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+  }
+`;

--- a/kor-react/src/components/shop/styles/userManagementModal.styles.ts
+++ b/kor-react/src/components/shop/styles/userManagementModal.styles.ts
@@ -16,26 +16,78 @@ export const modalOverlayStyle: React.CSSProperties = {
 
 export const modalContentStyle: React.CSSProperties = {
   backgroundColor: '#ffffff',
-  borderRadius: 8,
-  padding: '1.5rem',
+  borderRadius: 10,
+  padding: '1.25rem',
   width: '100%',
-  maxWidth: 520,
-  boxShadow: '0 10px 30px rgba(0,0,0,0.15)',
+  maxWidth: 560,
+  boxShadow: '0 12px 40px rgba(0,0,0,0.18)',
+};
+
+export const modalTitleRowStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  gap: '0.75rem',
 };
 
 export const modalHeaderStyle: React.CSSProperties = {
   margin: 0,
-  marginBottom: '0.25rem',
-  fontSize: '1.2rem',
-  fontWeight: 600,
-  color: '#222',
+  fontSize: '1.15rem',
+  fontWeight: 650,
+  color: '#1f2937',
+};
+
+export const closeIconButtonStyle: React.CSSProperties = {
+  border: '1px solid #e5e7eb',
+  backgroundColor: '#ffffff',
+  color: '#374151',
+  borderRadius: 8,
+  width: 34,
+  height: 34,
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  cursor: 'pointer',
+};
+
+export const tabsContainerStyle: React.CSSProperties = {
+  display: 'flex',
+  marginTop: '0.9rem',
+  borderBottom: '1px solid #eef0f3',
+};
+
+export const tabButtonStyle = (active: boolean): React.CSSProperties => ({
+  border: 'none',
+  background: 'transparent',
+  padding: '0.65rem 0.9rem',
+  cursor: 'pointer',
+  fontSize: '0.9rem',
+  fontWeight: active ? 650 : 550,
+  color: active ? '#111827' : '#6b7280',
+  borderBottom: active ? '2px solid #3B82F6' : '2px solid transparent',
+  marginBottom: -1,
+});
+
+export const tabPanelStyle: React.CSSProperties = {
+  paddingTop: '1rem',
 };
 
 export const modalSubtextStyle: React.CSSProperties = {
   margin: 0,
-  marginBottom: '1rem',
+  marginBottom: '0.9rem',
   fontSize: '0.9rem',
-  color: '#555',
+  color: '#4b5563',
+  lineHeight: 1.4,
+};
+
+export const infoNoticeStyle: React.CSSProperties = {
+  backgroundColor: '#f3f4f6',
+  border: '1px solid #e5e7eb',
+  color: '#374151',
+  padding: '0.6rem 0.75rem',
+  borderRadius: 8,
+  fontSize: '0.85rem',
+  marginBottom: '0.75rem',
 };
 
 export const userListContainerStyle: React.CSSProperties = {
@@ -49,20 +101,47 @@ export const userListItemStyle: React.CSSProperties = {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
-  padding: '0.5rem 0.25rem',
-  borderBottom: '1px solid #f1f1f1',
+  padding: '0.65rem 0.25rem',
+  borderBottom: '1px solid #f1f5f9',
+  gap: '0.75rem',
 };
 
 export const userListInfoStyle: React.CSSProperties = {
   display: 'flex',
   flexDirection: 'column',
-  marginRight: '0.75rem',
+  marginRight: '0.25rem',
+  minWidth: 0,
+  flex: '1 1 auto',
+};
+
+export const userListNameRowStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.5rem',
+  minWidth: 0,
 };
 
 export const userListNameStyle: React.CSSProperties = {
   fontSize: '0.95rem',
-  fontWeight: 500,
-  color: '#222',
+  fontWeight: 600,
+  color: '#111827',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+};
+
+export const adminBadgeStyle: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 6,
+  border: '1px solid #dbeafe',
+  backgroundColor: '#eff6ff',
+  color: '#1d4ed8',
+  padding: '0.15rem 0.45rem',
+  borderRadius: 999,
+  fontSize: '0.75rem',
+  fontWeight: 650,
+  flex: '0 0 auto',
 };
 
 export const userListEmailStyle: React.CSSProperties = {
@@ -71,18 +150,16 @@ export const userListEmailStyle: React.CSSProperties = {
 };
 
 export const deleteButtonStyle = (disabled: boolean): React.CSSProperties => ({
-  border: 'none',
-  backgroundColor: disabled ? '#f5b7b1' : '#e74c3c',
-  color: '#ffffff',
-  borderRadius: '50%',
-  width: 28,
-  height: 28,
-  display: 'flex',
+  border: '1px solid #fee2e2',
+  backgroundColor: disabled ? '#f9fafb' : '#ffffff',
+  color: disabled ? '#9ca3af' : '#dc2626',
+  borderRadius: 10,
+  width: 36,
+  height: 36,
+  display: 'inline-flex',
   alignItems: 'center',
   justifyContent: 'center',
   cursor: disabled ? 'not-allowed' : 'pointer',
-  fontSize: '0.9rem',
-  lineHeight: 1,
 });
 
 export const modalFooterStyle: React.CSSProperties = {
@@ -117,7 +194,41 @@ export const emptyStateStyle: React.CSSProperties = {
   textAlign: 'center',
   padding: '1rem 0.5rem',
   fontSize: '0.9rem',
-  color: '#777',
+  color: '#6b7280',
+};
+
+// Admin settings tab styles
+
+export const adminListContainerStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.5rem',
+  maxHeight: 320,
+  overflowY: 'auto',
+  paddingRight: 2,
+};
+
+export const adminListItemStyle: React.CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: '18px 1fr auto',
+  alignItems: 'center',
+  gap: '0.75rem',
+  padding: '0.65rem 0.75rem',
+  border: '1px solid #eef0f3',
+  borderRadius: 10,
+  cursor: 'pointer',
+  userSelect: 'none',
+};
+
+export const adminRadioStyle: React.CSSProperties = {
+  width: 16,
+  height: 16,
+};
+
+export const adminRowRightStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'flex-end',
 };
 
 // Confirm delete modal specific styles

--- a/kor-react/src/components/shop/styles/userManagementModal.styles.ts
+++ b/kor-react/src/components/shop/styles/userManagementModal.styles.ts
@@ -1,0 +1,162 @@
+// Styles for the family plan user management modal and confirm delete modal
+// Kept in plain objects for easy reuse and maintainability.
+
+export const modalOverlayStyle: React.CSSProperties = {
+  position: 'fixed',
+  top: 0,
+  left: 0,
+  width: '100%',
+  height: '100%',
+  backgroundColor: 'rgba(0,0,0,0.4)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 1000,
+};
+
+export const modalContentStyle: React.CSSProperties = {
+  backgroundColor: '#ffffff',
+  borderRadius: 8,
+  padding: '1.5rem',
+  width: '100%',
+  maxWidth: 520,
+  boxShadow: '0 10px 30px rgba(0,0,0,0.15)',
+};
+
+export const modalHeaderStyle: React.CSSProperties = {
+  margin: 0,
+  marginBottom: '0.25rem',
+  fontSize: '1.2rem',
+  fontWeight: 600,
+  color: '#222',
+};
+
+export const modalSubtextStyle: React.CSSProperties = {
+  margin: 0,
+  marginBottom: '1rem',
+  fontSize: '0.9rem',
+  color: '#555',
+};
+
+export const userListContainerStyle: React.CSSProperties = {
+  maxHeight: 320,
+  overflowY: 'auto',
+  marginTop: '0.5rem',
+  marginBottom: '1rem',
+};
+
+export const userListItemStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  padding: '0.5rem 0.25rem',
+  borderBottom: '1px solid #f1f1f1',
+};
+
+export const userListInfoStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  marginRight: '0.75rem',
+};
+
+export const userListNameStyle: React.CSSProperties = {
+  fontSize: '0.95rem',
+  fontWeight: 500,
+  color: '#222',
+};
+
+export const userListEmailStyle: React.CSSProperties = {
+  fontSize: '0.85rem',
+  color: '#666',
+};
+
+export const deleteButtonStyle = (disabled: boolean): React.CSSProperties => ({
+  border: 'none',
+  backgroundColor: disabled ? '#f5b7b1' : '#e74c3c',
+  color: '#ffffff',
+  borderRadius: '50%',
+  width: 28,
+  height: 28,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  cursor: disabled ? 'not-allowed' : 'pointer',
+  fontSize: '0.9rem',
+  lineHeight: 1,
+});
+
+export const modalFooterStyle: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'flex-end',
+  marginTop: '0.75rem',
+};
+
+export const modalButtonStyle = (
+  variant: 'primary' | 'secondary',
+): React.CSSProperties => ({
+  border: 'none',
+  borderRadius: 6,
+  padding: '0.5rem 1.1rem',
+  fontSize: '0.9rem',
+  cursor: 'pointer',
+  backgroundColor: variant === 'primary' ? '#3B82F6' : '#e0e0e0',
+  color: variant === 'primary' ? '#ffffff' : '#333333',
+  marginLeft: '0.5rem',
+});
+
+export const errorMessageStyle: React.CSSProperties = {
+  backgroundColor: '#ffe6e6',
+  color: '#c0392b',
+  padding: '0.5rem 0.75rem',
+  borderRadius: 4,
+  fontSize: '0.85rem',
+  marginBottom: '0.75rem',
+};
+
+export const emptyStateStyle: React.CSSProperties = {
+  textAlign: 'center',
+  padding: '1rem 0.5rem',
+  fontSize: '0.9rem',
+  color: '#777',
+};
+
+// Confirm delete modal specific styles
+
+export const confirmModalContentStyle: React.CSSProperties = {
+  ...modalContentStyle,
+  maxWidth: 460,
+};
+
+export const confirmModalHeaderStyle: React.CSSProperties = {
+  ...modalHeaderStyle,
+  marginBottom: '0.75rem',
+};
+
+export const confirmModalTextStyle: React.CSSProperties = {
+  ...modalSubtextStyle,
+  marginBottom: '1.25rem',
+};
+
+export const confirmModalFooterStyle: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'flex-end',
+  gap: '0.5rem',
+};
+
+export const confirmButtonStyle = (
+  variant: 'cancel' | 'danger',
+  disabled: boolean,
+): React.CSSProperties => ({
+  border: 'none',
+  borderRadius: 6,
+  padding: '0.5rem 1.1rem',
+  fontSize: '0.9rem',
+  cursor: disabled ? 'not-allowed' : 'pointer',
+  backgroundColor:
+    variant === 'danger'
+      ? disabled
+        ? '#f5b7b1'
+        : '#e74c3c'
+      : '#e0e0e0',
+  color: variant === 'danger' ? '#ffffff' : '#333333',
+});

--- a/kor-react/src/components/shop/types/shopUsersAndBikes.types.ts
+++ b/kor-react/src/components/shop/types/shopUsersAndBikes.types.ts
@@ -112,3 +112,12 @@ export interface ShopUsersAndBikesProps {
 }
 
 export type SortMode = 'wear_desc' | 'wear_asc';
+
+// Interface for family plan member in user management
+export interface FamilyMember {
+  id: number;
+  first_name: string;
+  last_name: string;
+  email: string;
+  strava_user_id?: number;
+}

--- a/kor-react/src/components/shop/types/shopUsersAndBikes.types.ts
+++ b/kor-react/src/components/shop/types/shopUsersAndBikes.types.ts
@@ -112,3 +112,12 @@ export interface ShopUsersAndBikesProps {
 }
 
 export type SortMode = 'wear_desc' | 'wear_asc';
+
+// Simple representation of a family plan member for management UI
+export interface FamilyMember {
+  id: number;
+  first_name: string;
+  last_name: string;
+  email: string;
+  strava_user_id: number;
+}

--- a/kor-react/src/components/shop/utils/familyPlanAdmin.ts
+++ b/kor-react/src/components/shop/utils/familyPlanAdmin.ts
@@ -1,0 +1,41 @@
+/**
+ * Utility functions for Family Plan Admin management
+ * 
+ * Centralizes logic for reading/writing admin ID to sessionStorage
+ * and dispatching admin update events.
+ */
+
+import { FAMILY_PLAN_STORAGE_KEYS, FAMILY_PLAN_EVENTS } from '../constants/familyPlan';
+
+/**
+ * Reads the admin user ID from sessionStorage
+ * @returns Admin user ID as a number, or null if not set or invalid
+ */
+export const getAdminUserId = (): number | null => {
+  if (typeof window === 'undefined') return null;
+  
+  const raw = sessionStorage.getItem(FAMILY_PLAN_STORAGE_KEYS.ADMIN_ID);
+  const parsed = raw ? Number(raw) : NaN;
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+/**
+ * Sets the admin user ID in sessionStorage and dispatches update event
+ * @param userId - The user ID to set as admin
+ */
+export const setAdminUserId = (userId: number): void => {
+  if (typeof window === 'undefined') return;
+  
+  sessionStorage.setItem(FAMILY_PLAN_STORAGE_KEYS.ADMIN_ID, String(userId));
+  window.dispatchEvent(new Event(FAMILY_PLAN_EVENTS.ADMIN_UPDATED));
+};
+
+/**
+ * Clears the admin user ID from sessionStorage and dispatches update event
+ */
+export const clearAdminUserId = (): void => {
+  if (typeof window === 'undefined') return;
+  
+  sessionStorage.removeItem(FAMILY_PLAN_STORAGE_KEYS.ADMIN_ID);
+  window.dispatchEvent(new Event(FAMILY_PLAN_EVENTS.ADMIN_UPDATED));
+};


### PR DESCRIPTION
Family plan admin dashboard: user management, admin selection, and wear tracking
This PR introduces the family plan admin experience for shop owners, allowing
them to manage members, assign an admin, and view a unified bike wear report
across all family members.

Feature additions:
- ManageUsersModal: two-tab modal for managing family plan users
    - Family Members tab: lists all members with delete (remove from plan) support
    - Admin Settings tab: radio-select to designate a family plan admin, saved
      via the setUserHead API with unsaved-changes tracking before save
    - ConfirmDeleteModal: two-step confirmation before removing a member
- FamilyPlanUsage section: live member count progress bar with optimistic
  decrement on delete and a Manage Users button to open the modal
- Admin identity resolution in ShopMaintenanceView: three-tier fallback chain
  (Auth0 email match → fetchShopUsers lookup → first-user default) that resolves
  which viewer is the admin and persists the selection in sessionStorage
- familyPlanAdmin util + familyPlan constants: centralized sessionStorage read/
  write for admin ID with a custom window event to keep components in sync
- "(You)" label on the UserCard for the currently identified admin viewer
- AllPartsWear admin indicator: blue dot on parts belonging to the viewer/admin,
  with a legend, and showAll state now resets when the view is toggled closed
- WearBar: new showAdminIndicator prop for the blue dot rendering
- PersonalPlans page: Chargebee drop-in checkout links for family plan monthly
  and yearly subscriptions, with Chargebee.registerAgain() on mount for React
  compatibility, plus plan selection UI for free/premium/family tiers

API layer (shopMaintenanceApi):
- fetchShopUsers: new endpoint for the manage-users modal user list
- removeUserShop: removes a user's shop association by Strava user ID
- setUserHead: designates a user as the family plan admin

Code quality fixes:
- Removed dead removeUserFromShop stub (console.log + setTimeout simulation)
- Removed hardcoded auth token fallback from getApiConfig
- Fixed Chargebee plan ID casing (Family-USD → family-USD, case-sensitive)
- Fixed part name search: removed term.includes(part) branch that caused any
  short search term to match all users
- Added missing type='button' on modal Close buttons
- Removed redundant setSelectedPlan call before navigation in PersonalPlans