### PR TITLE
Family Plan Admin Dashboard

### DIFF
--- a/kor-react/.env.example
+++ b/kor-react/.env.example
@@ -19,3 +19,8 @@ REACT_APP_AUTH0_AUDIENCE=your-auth0-api-audience
 # API Configuration
 REACT_APP_API_BASE_URL=http://localhost:3001
 REACT_APP_ENVIRONMENT=development
+
+# Family plan: set to true in .env.local to use the mock getShopHead
+# (returns first shop user instead of calling /getShopHead).
+# Remove or set to false before merging a PR.
+# REACT_APP_USE_MOCK_SHOP_HEAD=true

--- a/kor-react/.env.example
+++ b/kor-react/.env.example
@@ -18,9 +18,5 @@ REACT_APP_AUTH0_AUDIENCE=your-auth0-api-audience
 
 # API Configuration
 REACT_APP_API_BASE_URL=http://localhost:3001
+REACT_APP_API_AUTH_TOKEN=your-api-auth-token
 REACT_APP_ENVIRONMENT=development
-
-# Family plan: set to true in .env.local to use the mock getShopHead
-# (returns first shop user instead of calling /getShopHead).
-# Remove or set to false before merging a PR.
-# REACT_APP_USE_MOCK_SHOP_HEAD=true

--- a/kor-react/src/components/shop/ShopDashboard.tsx
+++ b/kor-react/src/components/shop/ShopDashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
 import { useNavigate } from 'react-router-dom';
 import { useLegacyParams, logLegacyParams } from '../../hooks/useLegacyParams';
@@ -9,6 +9,7 @@ import PlanSpecificModules from './modules/PlanSpecificModules';
 // Types and Hooks
 import { ShopUser, PlanFeatures } from './types';
 import { usePlanFeatures } from './hooks/usePlanFeatures';
+import { fetchShopUsers, getApiConfig } from './services/shopMaintenanceApi';
 
 // Plan configurations moved to usePlanFeatures hook
 
@@ -404,70 +405,29 @@ const ShopDashboard: React.FC = () => {
     }
   }, [shopUser, getPlanFeatures]);
 
-  // Function to fetch customer count (extracted for reusability)
-  const fetchCustomerCount = async () => {
-    const shop_token = sessionStorage.getItem('shop_token');
-    if (!shop_token) {
-      console.log(
-        'ℹ️ [ShopDashboard] No shop_token in sessionStorage; skipping user count fetch.'
-      );
-      return;
-    }
-
-    const baseUrl =
-      process.env.REACT_APP_API_BASE_URL || 'https://jmrcycling.com:3001';
-    const authToken =
-      process.env.REACT_APP_API_AUTH_TOKEN || '1893784827439273928203838';
+  // Fetch live customer count using existing backend API (works during soft-auth too)
+  const fetchCustomerCount = useCallback(async () => {
+    const config = getApiConfig();
+    if (!config.shopToken) return;
 
     setCustomerCountLoading(true);
     setCustomerCountError(null);
 
     try {
-      const response = await fetch(`${baseUrl}/getShopUsers`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        body: new URLSearchParams({
-          auth: authToken,
-          shop_token
-        }) as unknown as BodyInit,
-        redirect: 'follow' as RequestRedirect
-      });
-
-      if (!response.ok) {
-        const errText = await response.text().catch(() => '');
-        throw new Error(`HTTP ${response.status} ${errText}`);
-      }
-
-      const data = await response.json();
-      if (data && data.message === 'success') {
-        const count =
-          typeof data.user_count === 'number'
-            ? data.user_count
-            : Array.isArray(data.users)
-              ? data.users.length
-              : 0;
-        setCustomerCount(count);
-        console.log('👥 [ShopDashboard] Loaded customer count:', count);
-      } else {
-        throw new Error(data?.error || 'Failed to load user count');
-      }
+      const users = await fetchShopUsers(config);
+      setCustomerCount(users.length);
     } catch (err) {
-      console.error(
-        '❌ [ShopDashboard] Failed to fetch shop user count:',
-        err
-      );
       setCustomerCountError(
         err instanceof Error ? err.message : 'Unknown error'
       );
     } finally {
       setCustomerCountLoading(false);
     }
-  };
+  }, []);
 
-  // Fetch live customer count using existing backend API (works during soft-auth too)
   useEffect(() => {
     fetchCustomerCount();
-  }, [isAuthenticated, shopUser?.shopCode]);
+  }, [fetchCustomerCount, isAuthenticated, shopUser?.shopCode]);
 
   // Allow the dashboard to render if we have session-based shop data, even while Auth0 initializes
   const hasSessionShopData = !!(

--- a/kor-react/src/components/shop/ShopLogin.tsx
+++ b/kor-react/src/components/shop/ShopLogin.tsx
@@ -57,6 +57,11 @@ const ShopLogin: React.FC = () => {
       const result = await response.json();
 
       console.log('✅ [ShopLogin] API response received:', result);
+      console.log('🔍 [ShopLogin] strava_user_id check:', {
+        top_level: result.strava_user_id,
+        in_plan_type_0: result.plan_type?.[0]?.strava_user_id,
+        plan_type_0_keys: Object.keys(result.plan_type?.[0] || {})
+      });
       console.log('📊 [ShopLogin] Shop data:', {
         plan_type: result.plan_type[0].plan_type,
         shop_name: result.plan_type[0].shop_name,
@@ -69,6 +74,14 @@ const ShopLogin: React.FC = () => {
       sessionStorage.setItem('shop_code', result.plan_type[0].shop_code);
       sessionStorage.setItem('plan_type', result.plan_type[0].plan_type);
       sessionStorage.setItem('shop_token', result.plan_type[0].shop_token);
+
+      // Store the viewer's identity at login time, while Auth0 is still active.
+      // On subsequent page loads Auth0 silent auth often fails (e.g. localhost / 3rd-party cookies),
+      // so we can't rely on auth0User being populated later.
+      if (user.email) {
+        sessionStorage.setItem('user_email', user.email);
+      }
+
 
       console.log('💾 [ShopLogin] Data stored in sessionStorage:', {
         shop_name: sessionStorage.getItem('shop_name'),

--- a/kor-react/src/components/shop/ShopMaintenanceView.tsx
+++ b/kor-react/src/components/shop/ShopMaintenanceView.tsx
@@ -1,8 +1,7 @@
-import React, { useEffect, useState } from 'react';
-import { useAuth0 } from '@auth0/auth0-react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Loader2 } from 'lucide-react';
 import { useShopMaintenance } from './hooks/useShopMaintenance';
-import { fetchShopUsers, getApiConfig } from './services/shopMaintenanceApi';
+import { getShopHead, getApiConfig } from './services/shopMaintenanceApi';
 import { FAMILY_PLAN_EVENTS } from './constants/familyPlan';
 import {
   getAdminUserId,
@@ -38,9 +37,6 @@ const ShopMaintenanceView: React.FC<ShopUsersAndBikesProps> = ({
   readOnlyMode = false,
   showBikes = true
 }) => {
-  // Get all state and actions from our custom hook
-  const { user: auth0User } = useAuth0();
-
   const {
     users,
     allUsers,
@@ -62,7 +58,27 @@ const ShopMaintenanceView: React.FC<ShopUsersAndBikesProps> = ({
   const [sortMode, setSortMode] = useState<SortMode>('wear_desc');
 
   const [adminUserId, setAdminUserId] = useState<number | null>(getAdminUserId);
+  // useRef so the fetch-once guard doesn't trigger a re-render
+  const shopHeadFetchedRef = useRef(false);
 
+  // Fetch the server-stored admin once allUsers loads — shop_token is confirmed
+  // available at this point since fetchUsers already used it.
+  useEffect(() => {
+    if (shopHeadFetchedRef.current || allUsers.length === 0) return;
+
+    shopHeadFetchedRef.current = true;
+
+    getShopHead(getApiConfig())
+      .then(head => {
+        if (head != null) {
+          saveAdminUserId(head.strava_user_id);
+          setAdminUserId(head.strava_user_id);
+        }
+      })
+      .catch(err => console.error('[ShopMaintenanceView] getShopHead failed:', err));
+  }, [allUsers]);
+
+  // Keep in sync when admin changes via the Manage Users modal.
   useEffect(() => {
     if (typeof window === 'undefined') return;
 
@@ -74,101 +90,8 @@ const ShopMaintenanceView: React.FC<ShopUsersAndBikesProps> = ({
     return () => window.removeEventListener(FAMILY_PLAN_EVENTS.ADMIN_UPDATED, handleAdminUpdated);
   }, []);
 
-  const auth0EmailRaw =
-    typeof auth0User?.email === 'string'
-      ? auth0User.email
-      : typeof (auth0User as any)?.name === 'string'
-        ? (auth0User as any).name
-        : null;
-
-  const auth0Email =
-    typeof auth0EmailRaw === 'string' && auth0EmailRaw.includes('@')
-      ? auth0EmailRaw
-      : null;
-
-  // Resolve the currently logged-in user's Strava user id.
-  // NOTE: Some endpoints may not include email; if so, we fall back to `getShopUsers`.
-  const [currentUserId, setCurrentUserId] = useState<number | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    const resolveCurrentUserId = async () => {
-      if (!auth0Email) {
-        if (!cancelled) setCurrentUserId(null);
-        return;
-      }
-
-      // 1) Best case: maintenance report users include email
-      const directMatch = allUsers.find(
-        u => (u.email || '').toLowerCase() === auth0Email.toLowerCase()
-      );
-      if (directMatch?.strava_user_id != null) {
-        const parsed = Number((directMatch as any).strava_user_id);
-        if (!cancelled) setCurrentUserId(Number.isFinite(parsed) ? parsed : null);
-        return;
-      }
-
-      // 2) Fallback: fetch shop users list (includes email) to identify the viewer
-      try {
-        const config = getApiConfig();
-        const shopUsers = await fetchShopUsers(config);
-        const match = shopUsers.find(
-          (u: any) => (u?.email || '').toLowerCase() === auth0Email.toLowerCase()
-        );
-        const parsed = match?.strava_user_id != null ? Number(match.strava_user_id) : NaN;
-        if (!cancelled) setCurrentUserId(Number.isFinite(parsed) ? parsed : null);
-      } catch {
-        if (!cancelled) setCurrentUserId(null);
-      }
-    };
-
-    resolveCurrentUserId();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [allUsers, auth0Email]);
-
-  // If no admin has been selected yet, default to the current viewer.
-  // This ensures admin-only UI shows up immediately for the shop owner without requiring a modal selection.
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    if (adminUserId != null) return;
-    if (currentUserId == null) return;
-
-    saveAdminUserId(currentUserId);
-    setAdminUserId(currentUserId);
-  }, [adminUserId, currentUserId]);
-
-  // Soft-auth fallback: if we cannot resolve the viewer's Strava id (Auth0 not hydrated / blocked),
-  // assume the viewer is the admin for UI labeling purposes.
-  const viewerIsAdmin =
-    adminUserId != null && (currentUserId == null || adminUserId === currentUserId);
-
-  // Final fallback: if no admin is selected and we have users loaded, default to the first user.
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    if (adminUserId != null) return;
-    if (allUsers.length === 0) return;
-
-    const fallbackAdminId = Number((allUsers[0] as any).strava_user_id);
-    if (!Number.isFinite(fallbackAdminId)) return;
-
-    saveAdminUserId(fallbackAdminId);
-    setAdminUserId(fallbackAdminId);
-  }, [adminUserId, allUsers]);
-
-  useEffect(() => {
-    if (process.env.NODE_ENV !== 'development') return;
-    // eslint-disable-next-line no-console
-    console.debug('[ShopMaintenanceView] admin label state', {
-      auth0Email,
-      adminUserId,
-      currentUserId,
-      viewerIsAdmin,
-    });
-  }, [auth0Email, adminUserId, currentUserId, viewerIsAdmin]);
+  // Admin indicators show for whoever has head=1 in the DB — no email matching needed.
+  const viewerIsAdmin = adminUserId != null;
 
   /**
    * RENDERING: Clean and focused

--- a/kor-react/src/components/shop/WearBar/AllPartsWear.tsx
+++ b/kor-react/src/components/shop/WearBar/AllPartsWear.tsx
@@ -132,13 +132,12 @@ const AllPartsWear: React.FC<AllPartsWearProps> = ({
               adminUserId != null &&
               part.ownerId === adminUserId;
 
-            const label = part.label;
             const ownerLabel = isAdminOwner ? 'You' : part.ownerName;
 
             return (
               <div key={`${part.ownerId}-${part.bikeName}-${part.label}-${index}`}>
                 <WearBar
-                  label={label}
+                  label={part.label}
                   value={part.wearPercent}
                   imageSRC={part.icon}
                   showAdminIndicator={isAdminOwner}

--- a/kor-react/src/components/shop/components/ManageUsersModal.tsx
+++ b/kor-react/src/components/shop/components/ManageUsersModal.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
 import { Trash2, X, Shield } from 'lucide-react';
-import { FamilyMember } from '../types/shopUsersAndBikes.types';
 import {
+  ShopUser,
   fetchShopUsers,
+  getShopHead,
   removeUserShop,
   setUserHead,
   getApiConfig
@@ -37,9 +38,12 @@ import {
   adminRowRightStyle,
   infoNoticeStyle,
   modalFooterStyle,
+  adminFooterStyle,
   modalButtonStyle,
   errorMessageStyle,
-  emptyStateStyle
+  emptyStateStyle,
+  unsavedChangesBadgeStyle,
+  adminInnerStyle
 } from '../styles/userManagementModal.styles';
 
 interface ManageUsersModalProps {
@@ -58,10 +62,10 @@ const ManageUsersModal: React.FC<ManageUsersModalProps> = ({
   const { user: auth0User } = useAuth0();
 
   const [activeTab, setActiveTab] = useState<ManageUsersTab>('family');
-  const [users, setUsers] = useState<FamilyMember[]>([]);
+  const [users, setUsers] = useState<ShopUser[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [selectedUser, setSelectedUser] = useState<FamilyMember | null>(null);
+  const [selectedUser, setSelectedUser] = useState<ShopUser | null>(null);
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isSavingAdmin, setIsSavingAdmin] = useState(false);
@@ -71,36 +75,25 @@ const ManageUsersModal: React.FC<ManageUsersModalProps> = ({
   // Tracks the last successfully saved admin ID to detect changes.
   const [savedAdminId, setSavedAdminId] = useState<number | null>(null);
 
-  useEffect(() => {
-    if (isOpen) {
-      setActiveTab('family');
-
-      // Restore current admin selection from sessionStorage.
-      const adminId = getAdminUserId();
-      setSelectedAdminId(adminId);
-      setSavedAdminId(adminId); // Track as saved to detect changes
-
-      loadUsers();
-    }
-  }, [isOpen]);
-
-  const loadUsers = async () => {
+  const loadUsers = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
       const config = getApiConfig();
-      const fetchedUsers = await fetchShopUsers(config);
+      const [fetchedUsers, serverAdminId] = await Promise.all([
+        fetchShopUsers(config),
+        getShopHead(config).then(head => (head != null ? head.strava_user_id : null)).catch(() => null)
+      ]);
+      setUsers(fetchedUsers);
 
-      // Transform users to FamilyMember format
-      const familyMembers: FamilyMember[] = fetchedUsers.map(user => ({
-        id: user.strava_user_id,
-        first_name: user.first_name,
-        last_name: user.last_name,
-        email: user.email,
-        strava_user_id: user.strava_user_id
-      }));
+      // Server admin takes priority; fall back to whatever is in sessionStorage.
+      const adminId = serverAdminId ?? getAdminUserId();
+      setSelectedAdminId(adminId);
+      setSavedAdminId(adminId);
 
-      setUsers(familyMembers);
+      if (serverAdminId != null) {
+        saveAdminUserId(serverAdminId);
+      }
     } catch (err) {
       const errorMessage =
         err instanceof Error ? err.message : 'Failed to load users';
@@ -108,9 +101,16 @@ const ManageUsersModal: React.FC<ManageUsersModalProps> = ({
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
-  const handleDeleteClick = (user: FamilyMember) => {
+  useEffect(() => {
+    if (isOpen) {
+      setActiveTab('family');
+      loadUsers();
+    }
+  }, [isOpen, loadUsers]);
+
+  const handleDeleteClick = (user: ShopUser) => {
     setSelectedUser(user);
     setShowConfirmModal(true);
   };
@@ -122,13 +122,13 @@ const ManageUsersModal: React.FC<ManageUsersModalProps> = ({
     setError(null);
     try {
       const config = getApiConfig();
-      await removeUserShop(config, selectedUser.id);
+      await removeUserShop(config, selectedUser.strava_user_id);
 
       // Remove user from local state
-      setUsers(prev => prev.filter(u => u.id !== selectedUser.id));
+      setUsers(prev => prev.filter(u => u.strava_user_id !== selectedUser.strava_user_id));
 
       // If the deleted user was selected as admin, clear the selection.
-      setSelectedAdminId(prev => (prev === selectedUser.id ? null : prev));
+      setSelectedAdminId(prev => (prev === selectedUser.strava_user_id ? null : prev));
 
       // Close confirmation modal
       setShowConfirmModal(false);
@@ -187,21 +187,21 @@ const ManageUsersModal: React.FC<ManageUsersModalProps> = ({
 
   if (!isOpen) return null;
 
-  const getUserDisplayName = (user: FamilyMember): string => {
+  const getUserDisplayName = (user: ShopUser): string => {
     const fullName = `${user.first_name} ${user.last_name}`.trim();
     return fullName || user.email;
   };
 
   const auth0Email = typeof auth0User?.email === 'string' ? auth0User.email : null;
 
-  const isCurrentUser = (member: FamilyMember): boolean => {
+  const isCurrentUser = (member: ShopUser): boolean => {
     if (!auth0Email) return false;
     return member.email?.toLowerCase() === auth0Email.toLowerCase();
   };
 
-  const getUserDisplayNameWithYou = (member: FamilyMember): string => {
+  const getUserDisplayNameWithYou = (member: ShopUser): string => {
     const base = getUserDisplayName(member);
-    return selectedAdminId === member.id && isCurrentUser(member)
+    return selectedAdminId === member.strava_user_id && isCurrentUser(member)
       ? `${base} (You)`
       : base;
   };
@@ -209,7 +209,7 @@ const ManageUsersModal: React.FC<ManageUsersModalProps> = ({
   const selectedAdminUser =
     selectedAdminId == null
       ? null
-      : (users.find(u => u.id === selectedAdminId) ?? null);
+      : (users.find(u => u.strava_user_id === selectedAdminId) ?? null);
 
   const selectedAdminDisplayName = selectedAdminUser
     ? getUserDisplayNameWithYou(selectedAdminUser)
@@ -219,7 +219,7 @@ const ManageUsersModal: React.FC<ManageUsersModalProps> = ({
   const hasUnsavedChanges = selectedAdminId !== savedAdminId;
 
   const unsavedChangesBadge = hasUnsavedChanges ? (
-    <span style={{ color: '#f39c12', marginLeft: '0.5rem' }}>(Unsaved changes)</span>
+    <span style={unsavedChangesBadgeStyle}>(Unsaved changes)</span>
   ) : null;
 
   return (
@@ -271,13 +271,13 @@ const ManageUsersModal: React.FC<ManageUsersModalProps> = ({
                   <div style={emptyStateStyle}>No family members found</div>
                 ) : (
                   users.map(user => (
-                    <div key={user.id} style={userListItemStyle}>
+                    <div key={user.strava_user_id} style={userListItemStyle}>
                       <div style={userListInfoStyle}>
                         <div style={userListNameRowStyle}>
                           <div style={userListNameStyle}>
                             {getUserDisplayNameWithYou(user)}
                           </div>
-                          {selectedAdminId === user.id && (
+                          {selectedAdminId === user.strava_user_id && (
                             <span style={adminBadgeStyle}>
                               <Shield size={14} /> Admin
                             </span>
@@ -325,20 +325,20 @@ const ManageUsersModal: React.FC<ManageUsersModalProps> = ({
                   <div style={emptyStateStyle}>No family members found</div>
                 ) : (
                   users.map(user => (
-                    <label key={user.id} style={adminListItemStyle}>
+                    <label key={user.strava_user_id} style={adminListItemStyle}>
                       <input
                         type='radio'
                         name='family-plan-admin'
-                        checked={selectedAdminId === user.id}
-                        onChange={() => setSelectedAdminId(user.id)}
+                        checked={selectedAdminId === user.strava_user_id}
+                        onChange={() => setSelectedAdminId(user.strava_user_id)}
                         style={adminRadioStyle}
                       />
-                      <div style={{ minWidth: 0 }}>
+                      <div style={adminInnerStyle}>
                         <div style={userListNameStyle}>{getUserDisplayNameWithYou(user)}</div>
                         <div style={userListEmailStyle}>{user.email}</div>
                       </div>
                       <div style={adminRowRightStyle}>
-                        {selectedAdminId === user.id && (
+                        {selectedAdminId === user.strava_user_id && (
                           <span style={adminBadgeStyle}>
                             <Shield size={14} /> Admin
                           </span>
@@ -349,7 +349,7 @@ const ManageUsersModal: React.FC<ManageUsersModalProps> = ({
                 )}
               </div>
 
-              <div style={{ ...modalFooterStyle, gap: '0.5rem' }}>
+              <div style={adminFooterStyle}>
                 <button
                   type='button'
                   style={modalButtonStyle('secondary')}

--- a/kor-react/src/components/shop/components/ManageUsersModal.tsx
+++ b/kor-react/src/components/shop/components/ManageUsersModal.tsx
@@ -6,8 +6,7 @@ import {
   fetchShopUsers,
   removeUserShop,
   setUserHead,
-  getApiConfig,
-  FetchConfig
+  getApiConfig
 } from '../services/shopMaintenanceApi';
 import {
   getAdminUserId,
@@ -89,14 +88,14 @@ const ManageUsersModal: React.FC<ManageUsersModalProps> = ({
     setLoading(true);
     setError(null);
     try {
-      const config: FetchConfig = getApiConfig();
+      const config = getApiConfig();
       const fetchedUsers = await fetchShopUsers(config);
 
       // Transform users to FamilyMember format
-      const familyMembers: FamilyMember[] = fetchedUsers.map((user: any) => ({
+      const familyMembers: FamilyMember[] = fetchedUsers.map(user => ({
         id: user.strava_user_id,
-        first_name: user.first_name || '',
-        last_name: user.last_name || '',
+        first_name: user.first_name,
+        last_name: user.last_name,
         email: user.email,
         strava_user_id: user.strava_user_id
       }));
@@ -122,7 +121,7 @@ const ManageUsersModal: React.FC<ManageUsersModalProps> = ({
     setIsDeleting(true);
     setError(null);
     try {
-      const config: FetchConfig = getApiConfig();
+      const config = getApiConfig();
       await removeUserShop(config, selectedUser.id);
 
       // Remove user from local state
@@ -168,7 +167,7 @@ const ManageUsersModal: React.FC<ManageUsersModalProps> = ({
     setError(null);
 
     try {
-      const config: FetchConfig = getApiConfig();
+      const config = getApiConfig();
       await setUserHead(config, selectedAdminId);
 
       // Mark this selection as saved
@@ -218,6 +217,10 @@ const ManageUsersModal: React.FC<ManageUsersModalProps> = ({
 
   // Check if there are unsaved changes
   const hasUnsavedChanges = selectedAdminId !== savedAdminId;
+
+  const unsavedChangesBadge = hasUnsavedChanges ? (
+    <span style={{ color: '#f39c12', marginLeft: '0.5rem' }}>(Unsaved changes)</span>
+  ) : null;
 
   return (
     <>
@@ -306,20 +309,12 @@ const ManageUsersModal: React.FC<ManageUsersModalProps> = ({
               {selectedAdminUser ? (
                 <div style={infoNoticeStyle}>
                   Current admin: <strong>{selectedAdminDisplayName}</strong>
-                  {hasUnsavedChanges && (
-                    <span style={{ color: '#f39c12', marginLeft: '0.5rem' }}>
-                      (Unsaved changes)
-                    </span>
-                  )}
+                  {unsavedChangesBadge}
                 </div>
               ) : (
                 <div style={infoNoticeStyle}>
                   No admin selected
-                  {hasUnsavedChanges && (
-                    <span style={{ color: '#f39c12', marginLeft: '0.5rem' }}>
-                      (Unsaved changes)
-                    </span>
-                  )}
+                  {unsavedChangesBadge}
                 </div>
               )}
 

--- a/kor-react/src/components/shop/hooks/useShopMaintenance.ts
+++ b/kor-react/src/components/shop/hooks/useShopMaintenance.ts
@@ -125,7 +125,6 @@ export const useShopMaintenance = () => {
     });
   }, []);
 
-
   /**
    * Expand all bikes for all users
    * Also closes the All Parts view if it's open

--- a/kor-react/src/components/shop/sections/FamilyPlanUsage.tsx
+++ b/kor-react/src/components/shop/sections/FamilyPlanUsage.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect } from 'react';
 import { DashboardSectionProps, CustomerUsageProps } from '../types';
 import ManageUsersModal from '../components/ManageUsersModal';
+import { getShopHead, getApiConfig } from '../services/shopMaintenanceApi';
+import { setAdminUserId } from '../utils/familyPlanAdmin';
 
 interface FamilyPlanUsageProps
   extends DashboardSectionProps,
@@ -16,6 +18,21 @@ const FamilyPlanUsage: React.FC<FamilyPlanUsageProps> = ({
   onUserDeleted
 }) => {
   const [showManageUsersModal, setShowManageUsersModal] = useState(false);
+
+  // Fetch the current admin from the backend on mount so sessionStorage is
+  // populated before the modal is ever opened.
+  useEffect(() => {
+    const config = getApiConfig();
+    getShopHead(config)
+      .then(adminId => {
+        if (adminId != null) {
+          setAdminUserId(adminId);
+        }
+      })
+      .catch(err => {
+        console.warn('Could not fetch shop head on load:', err);
+      });
+  }, []);
 
   // Local copy of count so the bar updates immediately when a user is removed.
   const [effectiveCount, setEffectiveCount] = useState<number>(

--- a/kor-react/src/components/shop/sections/FamilyPlanUsage.tsx
+++ b/kor-react/src/components/shop/sections/FamilyPlanUsage.tsx
@@ -11,6 +11,7 @@ interface FamilyPlanUsageProps
 }
 
 const FamilyPlanUsage: React.FC<FamilyPlanUsageProps> = ({
+  shopUser,
   planFeatures,
   customerCount,
   customerCountLoading,
@@ -19,20 +20,23 @@ const FamilyPlanUsage: React.FC<FamilyPlanUsageProps> = ({
 }) => {
   const [showManageUsersModal, setShowManageUsersModal] = useState(false);
 
-  // Fetch the current admin from the backend on mount so sessionStorage is
-  // populated before the modal is ever opened.
+  // Fetch the current admin from the backend once the shop session is ready.
+  // shopUser?.shopCode is used as the trigger — it becomes non-null only after
+  // the login flow completes and sessionStorage is populated with shop_token.
   useEffect(() => {
     const config = getApiConfig();
+    if (!config.shopToken) return;
+
     getShopHead(config)
-      .then(adminId => {
-        if (adminId != null) {
-          setAdminUserId(adminId);
+      .then(head => {
+        if (head != null) {
+          setAdminUserId(head.strava_user_id);
         }
       })
       .catch(err => {
         console.warn('Could not fetch shop head on load:', err);
       });
-  }, []);
+  }, [shopUser?.shopCode]);
 
   // Local copy of count so the bar updates immediately when a user is removed.
   const [effectiveCount, setEffectiveCount] = useState<number>(
@@ -156,6 +160,7 @@ const FamilyPlanUsage: React.FC<FamilyPlanUsageProps> = ({
               }}
             >
               <button
+                type='button'
                 onClick={() => setShowManageUsersModal(true)}
                 style={{
                   backgroundColor: planFeatures?.color || '#007bff',

--- a/kor-react/src/components/shop/services/shopMaintenanceApi.ts
+++ b/kor-react/src/components/shop/services/shopMaintenanceApi.ts
@@ -11,6 +11,8 @@
 
 import { convertApiResponse } from '../modules/dataConverter';
 
+const FORM_ENCODED = 'application/x-www-form-urlencoded';
+
 export interface FetchConfig {
   baseUrl: string;
   authToken: string;
@@ -33,16 +35,26 @@ export interface ShopMaintenanceResponse {
   users: any[];
 }
 
+/** Shape of a user returned by /getShopUsers */
+export interface ShopUser {
+  strava_user_id: number;
+  first_name: string;
+  last_name: string;
+  email: string;
+}
+
 export interface RemoveUserShopResponse {
   message: string;
   strava_user_id: number | string;
   previous_shop_token?: string | null;
   updated: number;
+  error?: string;
 }
 
 export interface SetUserHeadResponse {
   message: string;
   strava_user_id: number | string;
+  error?: string;
 }
 
 /**
@@ -59,7 +71,7 @@ export const fetchShopMaintenanceReports = async (
 
   const response = await fetch(`${baseUrl}/GetShopMaintenanceReports`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    headers: { 'Content-Type': FORM_ENCODED },
     body: new URLSearchParams({
       auth: authToken,
       shop_token: shopToken
@@ -87,7 +99,7 @@ export const fetchShopMaintenanceReports = async (
  */
 export const fetchShopUsers = async (
   config: FetchConfig
-): Promise<any[]> => {
+): Promise<ShopUser[]> => {
   const { baseUrl, authToken, shopToken } = config;
 
   if (!shopToken) {
@@ -96,7 +108,7 @@ export const fetchShopUsers = async (
 
   const response = await fetch(`${baseUrl}/getShopUsers`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    headers: { 'Content-Type': FORM_ENCODED },
     body: new URLSearchParams({
       auth: authToken,
       shop_token: shopToken,
@@ -115,7 +127,7 @@ export const fetchShopUsers = async (
     throw new Error(data?.error || 'Unexpected response when loading users');
   }
 
-  return data.users;
+  return data.users as ShopUser[];
 };
 
 /**
@@ -132,7 +144,7 @@ export const removeUserShop = async (
   const { baseUrl } = config;
   const response = await fetch(`${baseUrl}/removeUserShop`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    headers: { 'Content-Type': FORM_ENCODED },
     body: new URLSearchParams({
       strava_user_id: String(stravaUserId)
     }) as unknown as BodyInit,
@@ -146,9 +158,7 @@ export const removeUserShop = async (
     );
   }
 
-  const data = (await response.json()) as RemoveUserShopResponse & {
-    error?: string;
-  };
+  const data = (await response.json()) as RemoveUserShopResponse;
 
   if (data?.message !== 'success') {
     throw new Error(data?.error || data?.message || 'Failed to remove user');
@@ -173,7 +183,7 @@ export const setUserHead = async (
 
   const response = await fetch(`${baseUrl}/setUserHead`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    headers: { 'Content-Type': FORM_ENCODED },
     body: new URLSearchParams({
       strava_user_id: String(stravaUserId)
     }) as unknown as BodyInit,
@@ -187,15 +197,86 @@ export const setUserHead = async (
     );
   }
 
-  const data = (await response.json()) as SetUserHeadResponse & {
-    error?: string;
-  };
+  const data = (await response.json()) as SetUserHeadResponse;
 
   if (data?.message !== 'success') {
     throw new Error(data?.error || data?.message || 'Failed to set user as admin');
   }
 
   return data;
+};
+
+export interface GetShopHeadResponse {
+  message: string;
+  shop_name: string;
+  shop_code: string;
+  shop_token: string;
+  head: {
+    strava_user_id: number;
+    first_name: string;
+    last_name: string;
+    email: string;
+    last_login?: string;
+    shop_activity?: string;
+  } | null;
+  info?: string;
+  error?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Mock flag for getShopHead
+//
+// /getShopHead is not yet deployed. Set REACT_APP_USE_MOCK_SHOP_HEAD=true in
+// .env.local (gitignored by CRA) to use the first shop user as the admin
+// while developing locally. .env.local is never included in production or CI
+// builds, so this flag cannot leak into a deployed environment.
+// ---------------------------------------------------------------------------
+const USE_MOCK_SHOP_HEAD = process.env.REACT_APP_USE_MOCK_SHOP_HEAD === 'true';
+
+if (USE_MOCK_SHOP_HEAD && process.env.NODE_ENV === 'development') {
+  // eslint-disable-next-line no-console
+  console.log(
+    '[DEV] getShopHead mock enabled: returning first shop user as admin. ' +
+      'Remove REACT_APP_USE_MOCK_SHOP_HEAD from .env.local to use the real endpoint.'
+  );
+}
+
+/**
+ * Gets the current head/admin of the family plan shop.
+ *
+ * Returns the strava_user_id of the head user, or null if no head is set.
+ */
+export const getShopHead = async (config: FetchConfig): Promise<number | null> => {
+  if (USE_MOCK_SHOP_HEAD) {
+    // Mock: pick the first user returned by the shop users list.
+    const users = await fetchShopUsers(config);
+    return users.length > 0 ? (users[0].strava_user_id as number) : null;
+  }
+
+  const { baseUrl, authToken, shopToken } = config;
+
+  const response = await fetch(`${baseUrl}/getShopHead`, {
+    method: 'POST',
+    headers: { 'Content-Type': FORM_ENCODED },
+    body: new URLSearchParams({
+      auth: authToken,
+      shop_token: shopToken
+    }) as unknown as BodyInit,
+    redirect: 'follow' as RequestRedirect
+  });
+
+  if (!response.ok) {
+    const errText = await response.text().catch(() => '');
+    throw new Error(`Failed to get shop head (HTTP ${response.status} ${errText})`);
+  }
+
+  const data = (await response.json()) as GetShopHeadResponse;
+
+  if (data?.message !== 'success') {
+    throw new Error(data?.error || 'Failed to get shop head');
+  }
+
+  return data.head?.strava_user_id ?? null;
 };
 
 /**

--- a/kor-react/src/components/shop/services/shopMaintenanceApi.ts
+++ b/kor-react/src/components/shop/services/shopMaintenanceApi.ts
@@ -133,9 +133,8 @@ export const fetchShopUsers = async (
 /**
  * Removes a user's association with the current shop.
  *
- * NOTE: This endpoint does not require auth or shop_token; it only
- * needs the Strava user id. We still use the shared baseUrl from config
- * to keep API configuration centralized.
+ * NOTE: Only `baseUrl` is used from config — this endpoint requires only
+ * the Strava user id, not auth or shop_token.
  */
 export const removeUserShop = async (
   config: FetchConfig,
@@ -223,36 +222,17 @@ export interface GetShopHeadResponse {
   error?: string;
 }
 
-// ---------------------------------------------------------------------------
-// Mock flag for getShopHead
-//
-// /getShopHead is not yet deployed. Set REACT_APP_USE_MOCK_SHOP_HEAD=true in
-// .env.local (gitignored by CRA) to use the first shop user as the admin
-// while developing locally. .env.local is never included in production or CI
-// builds, so this flag cannot leak into a deployed environment.
-// ---------------------------------------------------------------------------
-const USE_MOCK_SHOP_HEAD = process.env.REACT_APP_USE_MOCK_SHOP_HEAD === 'true';
-
-if (USE_MOCK_SHOP_HEAD && process.env.NODE_ENV === 'development') {
-  // eslint-disable-next-line no-console
-  console.log(
-    '[DEV] getShopHead mock enabled: returning first shop user as admin. ' +
-      'Remove REACT_APP_USE_MOCK_SHOP_HEAD from .env.local to use the real endpoint.'
-  );
+export interface ShopHeadData {
+  strava_user_id: number;
+  email: string;
 }
 
 /**
  * Gets the current head/admin of the family plan shop.
  *
- * Returns the strava_user_id of the head user, or null if no head is set.
+ * Returns { strava_user_id, email } of the head user, or null if no head is set.
  */
-export const getShopHead = async (config: FetchConfig): Promise<number | null> => {
-  if (USE_MOCK_SHOP_HEAD) {
-    // Mock: pick the first user returned by the shop users list.
-    const users = await fetchShopUsers(config);
-    return users.length > 0 ? (users[0].strava_user_id as number) : null;
-  }
-
+export const getShopHead = async (config: FetchConfig): Promise<ShopHeadData | null> => {
   const { baseUrl, authToken, shopToken } = config;
 
   const response = await fetch(`${baseUrl}/getShopHead`, {
@@ -276,7 +256,8 @@ export const getShopHead = async (config: FetchConfig): Promise<number | null> =
     throw new Error(data?.error || 'Failed to get shop head');
   }
 
-  return data.head?.strava_user_id ?? null;
+  if (data.head == null) return null;
+  return { strava_user_id: data.head.strava_user_id, email: data.head.email };
 };
 
 /**

--- a/kor-react/src/components/shop/styles/userManagementModal.styles.ts
+++ b/kor-react/src/components/shop/styles/userManagementModal.styles.ts
@@ -33,7 +33,7 @@ export const modalTitleRowStyle: React.CSSProperties = {
 export const modalHeaderStyle: React.CSSProperties = {
   margin: 0,
   fontSize: '1.15rem',
-  fontWeight: 650,
+  fontWeight: 700,
   color: '#1f2937',
 };
 
@@ -62,7 +62,7 @@ export const tabButtonStyle = (active: boolean): React.CSSProperties => ({
   padding: '0.65rem 0.9rem',
   cursor: 'pointer',
   fontSize: '0.9rem',
-  fontWeight: active ? 650 : 550,
+  fontWeight: active ? 600 : 500,
   color: active ? '#111827' : '#6b7280',
   borderBottom: active ? '2px solid #3B82F6' : '2px solid transparent',
   marginBottom: -1,
@@ -140,7 +140,7 @@ export const adminBadgeStyle: React.CSSProperties = {
   padding: '0.15rem 0.45rem',
   borderRadius: 999,
   fontSize: '0.75rem',
-  fontWeight: 650,
+  fontWeight: 700,
   flex: '0 0 auto',
 };
 
@@ -195,6 +195,22 @@ export const emptyStateStyle: React.CSSProperties = {
   padding: '1rem 0.5rem',
   fontSize: '0.9rem',
   color: '#6b7280',
+};
+
+export const unsavedChangesBadgeStyle: React.CSSProperties = {
+  color: '#f39c12',
+  marginLeft: '0.5rem',
+};
+
+export const adminInnerStyle: React.CSSProperties = {
+  minWidth: 0,
+};
+
+export const adminFooterStyle: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'flex-end',
+  marginTop: '0.75rem',
+  gap: '0.5rem',
 };
 
 // Admin settings tab styles

--- a/kor-react/src/components/shop/types/shopUsersAndBikes.types.ts
+++ b/kor-react/src/components/shop/types/shopUsersAndBikes.types.ts
@@ -112,12 +112,3 @@ export interface ShopUsersAndBikesProps {
 }
 
 export type SortMode = 'wear_desc' | 'wear_asc';
-
-// Simple representation of a family plan member for management UI
-export interface FamilyMember {
-  id: number;
-  first_name: string;
-  last_name: string;
-  email: string;
-  strava_user_id: number;
-}


### PR DESCRIPTION
## Family Plan Admin Dashboard

Adds admin management features to the family plan shop dashboard.

### What changed

**New: Manage Users modal** (`ManageUsersModal`, `ConfirmDeleteModal`)
- Two-tab modal: "Family Members" (remove users) and "Admin Settings" (select family plan head)
- Removes a user via `/removeUserShop` with a confirmation step
- Sets the family plan head via `/setUserHead`, persisted to the backend and reflected immediately in the dashboard

**New: Admin selection & `(You)` indicator**
- On load, `ShopMaintenanceView` and `FamilyPlanUsage` both call `/getShopHead` to resolve who the current admin is
- The admin's user card and wear bars are labeled `(You)` / highlighted with a blue dot
- Admin state is stored in `sessionStorage` and broadcast via a custom `family-admin-updated` event so all components stay in sync without prop drilling

**New API functions** (`shopMaintenanceApi.ts`)
- `fetchShopUsers` — lightweight user list for the modal
- `removeUserShop` — disassociate a user from the shop
- `setUserHead` / `getShopHead` — set/get the family plan admin

**Plan Usage section** (`FamilyPlanUsage`)
- Progress bar now updates optimistically when a user is deleted (no waiting for a re-fetch)
- "Manage Users" button opens the modal directly from the usage card

**Supporting files**
- `constants/familyPlan.ts` — storage key and event name constants
- `utils/familyPlanAdmin.ts` — read/write/clear admin ID in sessionStorage

### Context for reviewer
- The family plan head is stored server-side and fetched on mount. `sessionStorage` is used only as a local cache to survive page refreshes without a round trip.
- `ShopLogin` now stores `user_email` to `sessionStorage` at login time as a fallback for when Auth0 silent auth doesn't re-hydrate (common on localhost with 3rd-party cookie restrictions).