### PR TITLE
Part Replacement Modal

### DIFF
--- a/kor-react/src/components/shop/ShopLogin.tsx
+++ b/kor-react/src/components/shop/ShopLogin.tsx
@@ -57,17 +57,6 @@ const ShopLogin: React.FC = () => {
       const result = await response.json();
 
       console.log('✅ [ShopLogin] API response received:', result);
-      console.log('🔍 [ShopLogin] strava_user_id check:', {
-        top_level: result.strava_user_id,
-        in_plan_type_0: result.plan_type?.[0]?.strava_user_id,
-        plan_type_0_keys: Object.keys(result.plan_type?.[0] || {})
-      });
-      console.log('📊 [ShopLogin] Shop data:', {
-        plan_type: result.plan_type[0].plan_type,
-        shop_name: result.plan_type[0].shop_name,
-        shop_code: result.plan_type[0].shop_code,
-        shop_token: result.plan_type[0].shop_token
-      });
 
       // Store data in sessionStorage exactly like legacy system
       sessionStorage.setItem('shop_name', result.plan_type[0].shop_name);
@@ -81,7 +70,6 @@ const ShopLogin: React.FC = () => {
       if (user.email) {
         sessionStorage.setItem('user_email', user.email);
       }
-
 
       console.log('💾 [ShopLogin] Data stored in sessionStorage:', {
         shop_name: sessionStorage.getItem('shop_name'),

--- a/kor-react/src/components/shop/ShopMaintenanceView.tsx
+++ b/kor-react/src/components/shop/ShopMaintenanceView.tsx
@@ -46,10 +46,10 @@ const ShopMaintenanceView: React.FC<ShopUsersAndBikesProps> = ({
     search,
     showAllParts,
     allBikesExpanded,
-    actionError,
     setSearch,
     toggleShowAllParts,
     fetchUsers,
+    refreshUsers,
     toggleExpand,
     toggleAllBikes,
   } = useShopMaintenance();
@@ -90,8 +90,9 @@ const ShopMaintenanceView: React.FC<ShopUsersAndBikesProps> = ({
     return () => window.removeEventListener(FAMILY_PLAN_EVENTS.ADMIN_UPDATED, handleAdminUpdated);
   }, []);
 
-  // Admin indicators show for whoever has head=1 in the DB — no email matching needed.
-  const viewerIsAdmin = adminUserId != null;
+  // True when a family plan admin has been assigned in the DB.
+  // Used to show admin-highlight indicators (blue dot, "(You)" label) on the admin's entries.
+  const hasAdmin = adminUserId != null;
 
   /**
    * RENDERING: Clean and focused
@@ -127,13 +128,6 @@ const ShopMaintenanceView: React.FC<ShopUsersAndBikesProps> = ({
         {/* Error State */}
         {error && <div style={errorStyle}>Error loading users: {error}</div>}
 
-        {/* Action Error State (e.g., failed remove) */}
-        {actionError && (
-          <div style={{ ...errorStyle, marginTop: error ? '0.5rem' : 0 }}>
-            {actionError}
-          </div>
-        )}
-
         {/* Empty State */}
         {!loading && !error && users.length === 0 && (
           <div style={emptyStateStyle}>No users found.</div>
@@ -150,7 +144,8 @@ const ShopMaintenanceView: React.FC<ShopUsersAndBikesProps> = ({
                 showAllParts={showAllParts}
                 sortMode={sortMode}
                 adminUserId={adminUserId}
-                viewerIsAdmin={viewerIsAdmin}
+                hasAdmin={hasAdmin}
+                onRefresh={refreshUsers}
               />
             </div>
 
@@ -165,8 +160,8 @@ const ShopMaintenanceView: React.FC<ShopUsersAndBikesProps> = ({
                   expanded: false
                 };
 
-                const isAdminUser = adminUserId != null && user.strava_user_id === adminUserId;
-                const showYou = viewerIsAdmin && isAdminUser;
+                const isAdminUser = hasAdmin && user.strava_user_id === adminUserId;
+                const showYou = isAdminUser;
 
                 return (
                   <UserCard

--- a/kor-react/src/components/shop/WearBar/AllPartsWear.tsx
+++ b/kor-react/src/components/shop/WearBar/AllPartsWear.tsx
@@ -1,6 +1,8 @@
-import React, { useMemo, useEffect } from 'react';
+import React, { useMemo, useEffect, useState } from 'react';
+import { Wrench } from 'lucide-react';
 import WearBar from './index';
 import { getWearPartsForBike } from './partWear';
+import PartReplaceModal, { PartEntry } from './PartReplaceModal';
 
 interface User {
   strava_user_id: number;
@@ -16,19 +18,10 @@ interface AllPartsWearProps {
   filteredUsers: User[];
   bikesByUser: Record<string, BikeCollection>;
   showAllParts: boolean;
-  // Controls how parts are sorted; currently we only use wear_desc (most worn -> least worn)
   sortMode?: 'wear_desc' | 'wear_asc';
   adminUserId?: number | null;
-  viewerIsAdmin?: boolean;
-}
-
-interface PartEntry {
-  label: string;
-  wearPercent: number;
-  bikeName: string;
-  ownerName: string;
-  ownerId: number;
-  icon: string;
+  hasAdmin?: boolean;
+  onRefresh?: () => void;
 }
 
 const AllPartsWear: React.FC<AllPartsWearProps> = ({
@@ -37,9 +30,11 @@ const AllPartsWear: React.FC<AllPartsWearProps> = ({
   showAllParts,
   sortMode = 'wear_desc',
   adminUserId = null,
-  viewerIsAdmin = false,
+  hasAdmin = false,
+  onRefresh,
 }) => {
   const [showAll, setShowAll] = React.useState(false);
+  const [selectedPart, setSelectedPart] = useState<PartEntry | null>(null);
 
   useEffect(() => {
     if (!showAllParts) setShowAll(false);
@@ -65,13 +60,20 @@ const AllPartsWear: React.FC<AllPartsWearProps> = ({
             bikeName,
             ownerName,
             ownerId: user.strava_user_id,
-            icon: part.icon
+            icon: part.icon,
+            usedAmount: part.used,
+            periodAmount: part.period,
+            lastReplacedDate: part.lastReplacedDate,
+            bikeId: part.bikeId,
+            unit: part.unit,
+            partType: part.partType,
+            replaceEndpoint: part.replaceEndpoint,
+            usedBodyKey: part.usedBodyKey,
           });
         });
       });
     });
 
-    // Sort all parts by wear percentage based on sortMode
     return partsList.sort((a, b) =>
       sortMode === 'wear_asc'
         ? a.wearPercent - b.wearPercent
@@ -81,12 +83,9 @@ const AllPartsWear: React.FC<AllPartsWearProps> = ({
 
   if (!showAllParts || allParts.length === 0) return null;
   const visibleParts = showAll ? allParts : allParts.slice(0, 5);
+
   return (
-    <div
-      style={{
-        marginTop: '1rem'
-      }}
-    >
+    <div style={{ marginTop: '1rem' }}>
       <h3 style={{ color: '#333', marginBottom: '1rem' }}>All Part Wear</h3>
       <div
         style={{
@@ -97,7 +96,7 @@ const AllPartsWear: React.FC<AllPartsWearProps> = ({
         }}
       >
         {/* Legend */}
-        {viewerIsAdmin && adminUserId != null && (
+        {hasAdmin && (
           <div
             style={{
               display: 'flex',
@@ -123,25 +122,47 @@ const AllPartsWear: React.FC<AllPartsWearProps> = ({
             <span>Your parts</span>
           </div>
         )}
-        <div
-          style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}
-        >
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
           {visibleParts.map((part, index) => {
-            const isAdminOwner =
-              viewerIsAdmin &&
-              adminUserId != null &&
-              part.ownerId === adminUserId;
+            const isAdminOwner = hasAdmin && part.ownerId === adminUserId;
 
             const ownerLabel = isAdminOwner ? 'You' : part.ownerName;
 
             return (
               <div key={`${part.ownerId}-${part.bikeName}-${part.label}-${index}`}>
-                <WearBar
-                  label={part.label}
-                  value={part.wearPercent}
-                  imageSRC={part.icon}
-                  showAdminIndicator={isAdminOwner}
-                />
+                {/* WearBar row + wrench */}
+                <div style={{ display: 'flex', alignItems: 'center' }}>
+                  <div style={{ flex: 1 }}>
+                    <WearBar
+                      label={part.label}
+                      value={part.wearPercent}
+                      imageSRC={part.icon}
+                      showAdminIndicator={isAdminOwner}
+                      usedAmount={part.usedAmount}
+                      periodAmount={part.periodAmount}
+                      lastReplacedDate={part.lastReplacedDate}
+                      unit={part.unit}
+                    />
+                  </div>
+                  <button
+                    onClick={() => setSelectedPart(part)}
+                    title={`Replace ${part.label}`}
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      cursor: 'pointer',
+                      padding: '0 0.25rem 0 0.5rem',
+                      color: '#9ca3af',
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      flexShrink: 0,
+                    }}
+                    onMouseEnter={e => (e.currentTarget.style.color = '#3B82F6')}
+                    onMouseLeave={e => (e.currentTarget.style.color = '#9ca3af')}
+                  >
+                    <Wrench size={16} />
+                  </button>
+                </div>
                 <div
                   style={{
                     fontSize: '.9rem',
@@ -183,8 +204,6 @@ const AllPartsWear: React.FC<AllPartsWearProps> = ({
               }}
             >
               {showAll ? 'Show Less' : 'Show All'}
-
-              {/*Arrow*/}
               <span
                 style={{
                   display: 'flex',
@@ -199,6 +218,17 @@ const AllPartsWear: React.FC<AllPartsWearProps> = ({
           </div>
         )}
       </div>
+
+      {/* Replace modal — rendered once, driven by selectedPart */}
+      <PartReplaceModal
+        isOpen={selectedPart !== null}
+        onClose={() => setSelectedPart(null)}
+        part={selectedPart}
+        onSuccess={() => {
+          setSelectedPart(null);
+          onRefresh?.();
+        }}
+      />
     </div>
   );
 };

--- a/kor-react/src/components/shop/WearBar/PartReplaceModal.tsx
+++ b/kor-react/src/components/shop/WearBar/PartReplaceModal.tsx
@@ -1,0 +1,247 @@
+import React, { useState, useEffect } from 'react';
+import { X, CheckCircle } from 'lucide-react';
+import { replacePart, addMileage } from '../services/partReplaceApi';
+import { getApiConfig } from '../services/shopMaintenanceApi';
+import { formatReplacedDate, isChainLike, ADD_MILES_AMOUNT, ADD_HOURS_AMOUNT } from './wearUtils';
+import {
+  overlayStyle,
+  contentStyle,
+  titleRowStyle,
+  titleStyle,
+  closeButtonStyle,
+  wornTextStyle,
+  dateTextStyle,
+  questionStyle,
+  buttonRowStyle,
+  primaryButtonStyle,
+  secondaryButtonStyle,
+  dangerButtonStyle,
+  dividerStyle,
+  addButtonStyle,
+  errorStyle,
+  successContainerStyle,
+  successTextStyle,
+  disabledButtonStyle,
+} from '../styles/partReplaceModal.styles';
+
+export interface PartEntry {
+  label: string;
+  wearPercent: number;
+  bikeName: string;
+  ownerName: string;
+  ownerId: number;
+  icon: string;
+  usedAmount: number;
+  periodAmount: number;
+  lastReplacedDate: string | null;
+  bikeId: string | number;
+  unit: 'miles' | 'hours';
+  partType: string;
+  replaceEndpoint: string;
+  usedBodyKey: string;
+}
+
+interface PartReplaceModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  part: PartEntry | null;
+  onSuccess: () => void;
+}
+
+type ModalState = 'idle' | 'loading' | 'success' | 'error';
+type SuccessAction = 'replaced' | 'mileage_added' | null;
+
+const PartReplaceModal: React.FC<PartReplaceModalProps> = ({
+  isOpen,
+  onClose,
+  part,
+  onSuccess,
+}) => {
+  const [modalState, setModalState] = useState<ModalState>('idle');
+  const [errorMessage, setErrorMessage] = useState('');
+  const [successAction, setSuccessAction] = useState<SuccessAction>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setModalState('idle');
+      setErrorMessage('');
+      setSuccessAction(null);
+    }
+  }, [isOpen]);
+
+  if (!part || !isOpen) return null;
+
+  const chainLike = isChainLike(part.label);
+  const loading = modalState === 'loading';
+  const formattedDate = formatReplacedDate(part.lastReplacedDate);
+  const addLabel = part.unit === 'hours'
+    ? `Add ${ADD_HOURS_AMOUNT} Hours`
+    : `Add ${ADD_MILES_AMOUNT} Miles`;
+
+  const handleSuccess = (action: SuccessAction) => {
+    setSuccessAction(action);
+    setModalState('success');
+    setTimeout(() => {
+      onSuccess();
+    }, 1500);
+  };
+
+  const handleError = (err: unknown) => {
+    const msg = err instanceof Error ? err.message : 'Something went wrong';
+    setErrorMessage(msg);
+    setModalState('error');
+  };
+
+  const handleReplace = async (brokenWorn: 'worn_out' | 'broke') => {
+    setModalState('loading');
+    setErrorMessage('');
+    try {
+      const { baseUrl } = getApiConfig();
+      const extraBody: Record<string, string> | undefined =
+        part.partType === 'sealant'
+          ? { sealant_hour_marker: String(Math.floor(Date.now() / 1000 / 60 / 60)) }
+          : undefined;
+
+      await replacePart({
+        baseUrl,
+        stravaUserId: part.ownerId,
+        stravaWearBikeId: part.bikeId,
+        bikeName: part.bikeName,
+        replaceEndpoint: part.replaceEndpoint,
+        usedBodyKey: part.usedBodyKey,
+        partType: part.partType,
+        usedAmount: part.usedAmount,
+        brokenWorn,
+        extraBody,
+      });
+      handleSuccess('replaced');
+    } catch (err) {
+      handleError(err);
+    }
+  };
+
+  const handleAddMileage = async () => {
+    setModalState('loading');
+    setErrorMessage('');
+    try {
+      const { baseUrl } = getApiConfig();
+      await addMileage({
+        baseUrl,
+        stravaUserId: part.ownerId,
+        bikeId: part.bikeId,
+        bikeName: part.bikeName,
+        partType: part.partType,
+        usedBodyKey: part.usedBodyKey,
+        unit: part.unit,
+      });
+      handleSuccess('mileage_added');
+    } catch (err) {
+      handleError(err);
+    }
+  };
+
+  const handleClose = () => {
+    if (loading) return;
+    setModalState('idle');
+    setErrorMessage('');
+    onClose();
+  };
+
+  return (
+    <div style={overlayStyle} onClick={handleClose}>
+      <div style={contentStyle} onClick={e => e.stopPropagation()}>
+        {/* Success state */}
+        {modalState === 'success' ? (
+          <div style={successContainerStyle}>
+            <CheckCircle size={36} color="#16a34a" />
+            <p style={successTextStyle}>
+              {successAction === 'mileage_added'
+                ? part.unit === 'hours'
+                  ? `${ADD_HOURS_AMOUNT} hours added!`
+                  : `${ADD_MILES_AMOUNT} miles added!`
+                : 'Part replaced!'}
+            </p>
+          </div>
+        ) : (
+          <>
+            {/* Header */}
+            <div style={titleRowStyle}>
+              <h2 style={titleStyle}>{part.label}</h2>
+              <button style={closeButtonStyle} onClick={handleClose} disabled={loading}>
+                <X size={18} />
+              </button>
+            </div>
+
+            {/* Wear info */}
+            <p style={wornTextStyle}>
+              Worn: {part.usedAmount.toLocaleString()} out of {part.periodAmount.toLocaleString()} {part.unit}
+            </p>
+            {formattedDate && (
+              <p style={dateTextStyle}>Last replaced {formattedDate}</p>
+            )}
+
+            {/* Error */}
+            {modalState === 'error' && (
+              <div style={errorStyle}>{errorMessage}</div>
+            )}
+
+            {/* Action buttons */}
+            {chainLike ? (
+              <>
+                <p style={questionStyle}>How did the {part.label.toLowerCase()} reach replacement time?</p>
+                <div style={buttonRowStyle}>
+                  <button
+                    style={loading ? disabledButtonStyle(primaryButtonStyle) : primaryButtonStyle}
+                    onClick={() => handleReplace('worn_out')}
+                    disabled={loading}
+                  >
+                    Worn Out
+                  </button>
+                  <button
+                    style={loading ? disabledButtonStyle(dangerButtonStyle) : dangerButtonStyle}
+                    onClick={() => handleReplace('broke')}
+                    disabled={loading}
+                  >
+                    Broke
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <p style={questionStyle}>Do you need to replace it?</p>
+                <div style={buttonRowStyle}>
+                  <button
+                    style={loading ? disabledButtonStyle(primaryButtonStyle) : primaryButtonStyle}
+                    onClick={() => handleReplace('worn_out')}
+                    disabled={loading}
+                  >
+                    Yes
+                  </button>
+                  <button
+                    style={loading ? disabledButtonStyle(secondaryButtonStyle) : secondaryButtonStyle}
+                    onClick={handleClose}
+                    disabled={loading}
+                  >
+                    No
+                  </button>
+                </div>
+              </>
+            )}
+
+            {/* Add mileage section */}
+            <div style={dividerStyle} />
+            <button
+              style={loading ? disabledButtonStyle(addButtonStyle) : addButtonStyle}
+              onClick={handleAddMileage}
+              disabled={loading}
+            >
+              {loading ? 'Working…' : addLabel}
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default PartReplaceModal;

--- a/kor-react/src/components/shop/WearBar/index.tsx
+++ b/kor-react/src/components/shop/WearBar/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Box, Typography, LinearProgress } from '@mui/material';
+import { Box, Typography, LinearProgress, Tooltip } from '@mui/material';
+import { buildTooltipText } from './wearUtils';
 
 interface WearBarProps {
   label: string;
@@ -7,6 +8,11 @@ interface WearBarProps {
   threshold?: number;
   imageSRC: string;
   showAdminIndicator?: boolean;
+  // Optional — tooltip is suppressed when omitted
+  usedAmount?: number;
+  periodAmount?: number;
+  lastReplacedDate?: string | null;
+  unit?: 'miles' | 'hours';
 }
 
 const WearBar: React.FC<WearBarProps> = ({
@@ -14,9 +20,12 @@ const WearBar: React.FC<WearBarProps> = ({
   value,
   threshold = 75,
   imageSRC,
-  showAdminIndicator = false
+  showAdminIndicator = false,
+  usedAmount,
+  periodAmount,
+  lastReplacedDate,
+  unit = 'miles',
 }) => {
-  // Determine bar color based on wear percentage
   let barColor = '#00FF75';
   if (value === 100) {
     barColor = '#FF1744';
@@ -24,7 +33,12 @@ const WearBar: React.FC<WearBarProps> = ({
     barColor = '#FFD700';
   }
 
-  return (
+  const tooltipText =
+    usedAmount !== undefined && periodAmount !== undefined
+      ? buildTooltipText(label, usedAmount, periodAmount, unit, lastReplacedDate)
+      : '';
+
+  const bar = (
     <Box
       sx={{
         display: 'flex',
@@ -54,14 +68,14 @@ const WearBar: React.FC<WearBarProps> = ({
           style={{ width: '100%', height: '100%', objectFit: 'contain' }}
         />
       </Box>
-      {/* Label on the left */}
+      {/* Label */}
       <Typography
         variant='body1'
         sx={{
-          width: 100, // fixed width ensures all labels take same space
+          width: 100,
           textAlign: 'left',
           fontWeight: 600,
-          flexShrink: 0 // prevents shrinking for long labels
+          flexShrink: 0
         }}
       >
         {label}
@@ -96,11 +110,11 @@ const WearBar: React.FC<WearBarProps> = ({
         />
       </Box>
 
-      {/* Percentage on the right */}
+      {/* Percentage */}
       <Typography
         variant='body1'
         sx={{
-          width: 40, // fixed width ensures alignment
+          width: 40,
           textAlign: 'right',
           fontWeight: 600,
           flexShrink: 0
@@ -109,6 +123,18 @@ const WearBar: React.FC<WearBarProps> = ({
         {value}%
       </Typography>
     </Box>
+  );
+
+  if (!tooltipText) return bar;
+
+  return (
+    <Tooltip
+      title={<span style={{ whiteSpace: 'pre-line' }}>{tooltipText}</span>}
+      placement='top'
+      arrow
+    >
+      {bar}
+    </Tooltip>
   );
 };
 

--- a/kor-react/src/components/shop/WearBar/partWear.ts
+++ b/kor-react/src/components/shop/WearBar/partWear.ts
@@ -24,17 +24,183 @@ export const partIcons: Record<string, string> = {
   sealant: sealantIcon
 };
 
+// ---------------------------------------------------------------------------
+// PART_CONFIG — single source of truth for all part metadata
+// ---------------------------------------------------------------------------
+
+export interface PartConfig {
+  label: string;
+  icon: string;
+  unit: 'miles' | 'hours';
+  partType: string;
+  replaceEndpoint: string;
+  usedBodyKey: string;
+  getUsed: (pd: any) => number;
+  getPeriod: (sp: any) => number;
+  getDate: (pd: any) => string | null;
+  getShow: (pd: any) => boolean;
+}
+
+export const PART_CONFIGS: PartConfig[] = [
+  {
+    label: 'Chain',
+    icon: partIcons.chain,
+    unit: 'miles',
+    partType: 'chain',
+    replaceEndpoint: '/newChain',
+    usedBodyKey: 'chain_used_miles',
+    getUsed: pd => pd.chain_used_miles ?? 0,
+    getPeriod: sp => sp.chain_miles ?? 0,
+    getDate: pd => pd.new_chain_date ?? null,
+    getShow: () => true,
+  },
+  {
+    label: 'Cassette',
+    icon: partIcons.cassette,
+    unit: 'miles',
+    partType: 'cassette',
+    replaceEndpoint: '/newCassette',
+    usedBodyKey: 'cassette_used_miles',
+    getUsed: pd => pd.cassette_used_miles ?? 0,
+    getPeriod: sp => sp.cassette_miles ?? 0,
+    getDate: pd => pd.new_cassette_date ?? null,
+    getShow: () => true,
+  },
+  {
+    label: 'Chain Ring',
+    icon: partIcons.chain_ring,
+    unit: 'miles',
+    partType: 'chain ring',
+    replaceEndpoint: '/newChainRing',
+    usedBodyKey: 'chain_ring_used_miles',
+    getUsed: pd => pd.chain_ring_used_miles ?? 0,
+    getPeriod: sp => sp.chain_ring_miles ?? 0,
+    getDate: pd => pd.new_chain_ring_date ?? null,
+    getShow: () => true,
+  },
+  {
+    label: 'Bottom Bracket',
+    icon: partIcons.bottom_bracket,
+    unit: 'miles',
+    partType: 'bottom bracket',
+    replaceEndpoint: '/newBottomBracket',
+    usedBodyKey: 'bottom_bracket_used_miles',
+    getUsed: pd => pd.bottom_bracket_used_miles ?? 0,
+    getPeriod: sp => sp.bottom_bracket_miles ?? 0,
+    getDate: pd => pd.new_bottom_bracket_date ?? null,
+    getShow: () => true,
+  },
+  {
+    label: 'Front Fork',
+    icon: partIcons.front_fork,
+    unit: 'miles',
+    partType: 'front fork',
+    replaceEndpoint: '/frontForkService',
+    usedBodyKey: 'front_fork_used_miles',
+    getUsed: pd => pd.front_fork_used_miles ?? 0,
+    getPeriod: sp => sp.front_fork_miles ?? 0,
+    getDate: pd => pd.front_fork_service_date ?? null,
+    getShow: pd => Boolean(pd.front_fork_show),
+  },
+  {
+    label: 'Rear Shock',
+    icon: partIcons.rear_shock,
+    unit: 'miles',
+    partType: 'rear shock',
+    replaceEndpoint: '/rearShockService',
+    usedBodyKey: 'rear_shock_used_hours',
+    getUsed: pd => pd.rear_shock_used_miles ?? 0,
+    getPeriod: sp => sp.rear_shock_miles ?? 0,
+    getDate: pd => pd.rear_shock_service_date ?? null,
+    getShow: pd => Boolean(pd.rear_suspension_show),
+  },
+  {
+    label: 'Brake Pads',
+    icon: partIcons.brake_pads,
+    unit: 'miles',
+    partType: 'brake pads',
+    replaceEndpoint: '/newBrakePads',
+    usedBodyKey: 'brake_pads_used_miles',
+    getUsed: pd => pd.brake_pads_used_miles ?? 0,
+    getPeriod: sp => sp.brake_pads_miles ?? 0,
+    getDate: pd => pd.new_brake_pads_date ?? null,
+    getShow: pd => Boolean(pd.brake_pads_show || pd.brake_pad_show),
+  },
+  {
+    label: 'Brake Rotors',
+    icon: partIcons.brake_rotors,
+    unit: 'miles',
+    partType: 'brake rotors',
+    replaceEndpoint: '/newBrakeRotors',
+    usedBodyKey: 'brake_rotors_used_miles',
+    getUsed: pd => pd.brake_rotors_used_miles ?? 0,
+    getPeriod: sp => sp.brake_rotors_miles ?? 0,
+    getDate: pd => pd.new_brake_rotors_date ?? null,
+    getShow: pd => Boolean(pd.brake_rotors_show || pd.brake_rotor_show),
+  },
+  {
+    label: 'Dropper',
+    icon: partIcons.dropper,
+    unit: 'miles',
+    partType: 'dropper',
+    replaceEndpoint: '/DropperService',
+    usedBodyKey: 'dropper_used_miles',
+    getUsed: pd => pd.dropper_used_miles ?? 0,
+    getPeriod: sp => sp.dropper_miles ?? 0,
+    getDate: pd => pd.dropper_service_date ?? null,
+    getShow: pd => Boolean(pd.dropper_show),
+  },
+  {
+    label: 'Tires',
+    icon: partIcons.tires,
+    unit: 'miles',
+    partType: 'tires',
+    replaceEndpoint: '/newTires',
+    usedBodyKey: 'tires_used_miles',
+    getUsed: pd => pd.tires_used_miles ?? 0,
+    getPeriod: sp => sp.tires_miles ?? 0,
+    getDate: pd => pd.new_tires_date ?? null,
+    getShow: () => true,
+  },
+  {
+    label: 'Sealant',
+    icon: partIcons.sealant,
+    unit: 'hours',
+    partType: 'sealant',
+    replaceEndpoint: '/sealantRefresh',
+    usedBodyKey: 'sealant_used_hours',
+    getUsed: pd => pd.sealant_used_hours ?? 0,
+    getPeriod: sp => sp.sealant_refresh_hours ?? 0,
+    getDate: pd => pd.sealant_refresh_date ?? null,
+    getShow: pd => Boolean(pd.sealant_show),
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
 export interface PartDefinition {
   label: string;
   used: number;
   period: number;
   icon: string;
   show: boolean;
+  unit: 'miles' | 'hours';
+  partType: string;
+  replaceEndpoint: string;
+  usedBodyKey: string;
+  lastReplacedDate: string | null;
+  bikeId: string | number;
 }
 
 export interface WearPart extends PartDefinition {
   wearPercent: number;
 }
+
+// ---------------------------------------------------------------------------
+// Builders
+// ---------------------------------------------------------------------------
 
 /**
  * Build all part definitions for a given bike (including hidden ones).
@@ -43,86 +209,21 @@ export const buildPartsForBike = (bike: any): PartDefinition[] => {
   if (!bike || !bike.part_data || !bike.service_periods) return [];
 
   const { part_data, service_periods } = bike;
+  const bikeId = part_data.strava_bike_id ?? '';
 
-  return [
-    {
-      label: 'Chain',
-      used: part_data.chain_used_miles ?? 0,
-      period: service_periods.chain_miles ?? 0,
-      icon: partIcons.chain,
-      show: true // Chain always shows
-    },
-    {
-      label: 'Cassette',
-      used: part_data.cassette_used_miles ?? 0,
-      period: service_periods.cassette_miles ?? 0,
-      icon: partIcons.cassette,
-      show: true // Cassette always shows
-    },
-    {
-      label: 'Chain Ring',
-      used: part_data.chain_ring_used_miles ?? 0,
-      period: service_periods.chain_ring_miles ?? 0,
-      icon: partIcons.chain_ring,
-      show: true // Chain ring always shows
-    },
-    {
-      label: 'Bottom Bracket',
-      used: part_data.bottom_bracket_used_miles ?? 0,
-      period: service_periods.bottom_bracket_miles ?? 0,
-      icon: partIcons.bottom_bracket,
-      show: true // Bottom bracket always shows
-    },
-    {
-      label: 'Front Fork',
-      used: part_data.front_fork_used_miles ?? 0,
-      period: service_periods.front_fork_miles ?? 0,
-      icon: partIcons.front_fork,
-      show: Boolean(part_data.front_fork_show)
-    },
-    {
-      label: 'Rear Shock',
-      used: part_data.rear_shock_used_miles ?? 0,
-      period: service_periods.rear_shock_miles ?? 0,
-      icon: partIcons.rear_shock,
-      show: Boolean(part_data.rear_suspension_show)
-    },
-    {
-      label: 'Brake Pads',
-      used: part_data.brake_pads_used_miles ?? 0,
-      period: service_periods.brake_pads_miles ?? 0,
-      icon: partIcons.brake_pads,
-      show: Boolean(part_data.brake_pads_show || part_data.brake_pad_show)
-    },
-    {
-      label: 'Brake Rotors',
-      used: part_data.brake_rotors_used_miles ?? 0,
-      period: service_periods.brake_rotors_miles ?? 0,
-      icon: partIcons.brake_rotors,
-      show: Boolean(part_data.brake_rotors_show || part_data.brake_rotor_show)
-    },
-    {
-      label: 'Dropper',
-      used: part_data.dropper_used_miles ?? 0,
-      period: service_periods.dropper_miles ?? 0,
-      icon: partIcons.dropper,
-      show: Boolean(part_data.dropper_show)
-    },
-    {
-      label: 'Tires',
-      used: part_data.tires_used_miles ?? 0,
-      period: service_periods.tires_miles ?? 0,
-      icon: partIcons.tires,
-      show: true // Tires always show
-    },
-    {
-      label: 'Sealant',
-      used: part_data.sealant_used_hours ?? 0,
-      period: service_periods.sealant_refresh_hours ?? 0,
-      icon: partIcons.sealant,
-      show: Boolean(part_data.sealant_show)
-    }
-  ];
+  return PART_CONFIGS.map(config => ({
+    label: config.label,
+    used: config.getUsed(part_data),
+    period: config.getPeriod(service_periods),
+    icon: config.icon,
+    show: config.getShow(part_data),
+    unit: config.unit,
+    partType: config.partType,
+    replaceEndpoint: config.replaceEndpoint,
+    usedBodyKey: config.usedBodyKey,
+    lastReplacedDate: config.getDate(part_data),
+    bikeId,
+  }));
 };
 
 /**

--- a/kor-react/src/components/shop/WearBar/wearUtils.ts
+++ b/kor-react/src/components/shop/WearBar/wearUtils.ts
@@ -1,0 +1,41 @@
+export const ADD_MILES_AMOUNT = 100;
+export const ADD_HOURS_AMOUNT = 100;
+
+/**
+ * Formats an ISO date string (e.g. "2024-01-15T00:00:00") to "January 15, 2024".
+ * Parses as local date to avoid timezone shift issues.
+ */
+export const formatReplacedDate = (isoDate: string | null | undefined): string | null => {
+  if (!isoDate) return null;
+  const [year, month, day] = isoDate.split('T')[0].split('-').map(Number);
+  return new Date(year, month - 1, day).toLocaleDateString('en-US', {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric',
+  });
+};
+
+/**
+ * Builds the tooltip text shown on hover over a WearBar.
+ */
+export const buildTooltipText = (
+  label: string,
+  used: number,
+  period: number,
+  unit: 'miles' | 'hours',
+  lastReplacedDate: string | null | undefined,
+): string => {
+  const wearPercent = period > 0 ? Math.min(Math.round((used / period) * 100), 100) : 0;
+  const formattedDate = formatReplacedDate(lastReplacedDate);
+  let text = `${label}: worn ${used.toLocaleString()} out of ${period.toLocaleString()} ${unit} (${wearPercent}%)`;
+  if (formattedDate) {
+    text += `\nLast replaced on ${formattedDate}`;
+  }
+  return text;
+};
+
+/**
+ * Returns true for parts that use the "Worn Out / Broke" two-button variant.
+ */
+export const isChainLike = (label: string): boolean =>
+  label === 'Chain' || label === 'Cassette';

--- a/kor-react/src/components/shop/components/ManageUsersModal.tsx
+++ b/kor-react/src/components/shop/components/ManageUsersModal.tsx
@@ -184,7 +184,6 @@ const ManageUsersModal: React.FC<ManageUsersModalProps> = ({
     }
   };
 
-
   if (!isOpen) return null;
 
   const getUserDisplayName = (user: ShopUser): string => {
@@ -192,11 +191,15 @@ const ManageUsersModal: React.FC<ManageUsersModalProps> = ({
     return fullName || user.email;
   };
 
-  const auth0Email = typeof auth0User?.email === 'string' ? auth0User.email : null;
+  // Auth0 silent auth often fails on subsequent page loads (3rd-party cookie restrictions),
+  // so fall back to the email stored in sessionStorage at login time.
+  const currentEmail =
+    (typeof auth0User?.email === 'string' ? auth0User.email : null) ??
+    sessionStorage.getItem('user_email');
 
   const isCurrentUser = (member: ShopUser): boolean => {
-    if (!auth0Email) return false;
-    return member.email?.toLowerCase() === auth0Email.toLowerCase();
+    if (!currentEmail) return false;
+    return member.email?.toLowerCase() === currentEmail.toLowerCase();
   };
 
   const getUserDisplayNameWithYou = (member: ShopUser): string => {

--- a/kor-react/src/components/shop/hooks/useShopMaintenance.ts
+++ b/kor-react/src/components/shop/hooks/useShopMaintenance.ts
@@ -36,7 +36,6 @@ export const useShopMaintenance = () => {
   // STATE: UI state
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [actionError, setActionError] = useState<string | null>(null);
   const [search, setSearch] = useState('');
   const [showAllParts, setShowAllParts] = useState(false);
   const [allBikesExpanded, setAllBikesExpanded] = useState(false);
@@ -45,18 +44,13 @@ export const useShopMaintenance = () => {
    * USECALLBACK: Memoizes function to prevent unnecessary re-renders
    * WHY: Function reference stays same unless dependencies change
    */
-  const fetchUsers = useCallback(async () => {
-    setLoading(true);
+  const loadUsers = useCallback(async (silent: boolean) => {
+    if (!silent) setLoading(true);
     setError(null);
-    setActionError(null);
-    
-    // Reset UI states when refreshing
-    setShowAllParts(false);
-    setAllBikesExpanded(false);
 
     try {
       const config = getApiConfig();
-      
+
       if (!config.shopToken) {
         throw new Error('Missing shop_token. Please log in again.');
       }
@@ -93,9 +87,12 @@ export const useShopMaintenance = () => {
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to load users');
     } finally {
-      setLoading(false);
+      if (!silent) setLoading(false);
     }
-  }, []); // No dependencies = function created once
+  }, []);
+
+  const fetchUsers = useCallback(() => loadUsers(false), [loadUsers]);
+  const refreshUsers = useCallback(() => loadUsers(true), [loadUsers]);
 
   /**
    * USEEFFECT: Runs on component mount
@@ -259,14 +256,12 @@ export const useShopMaintenance = () => {
     showAllParts,
     allBikesExpanded,
 
-    // Action state
-    actionError,
-    
     // Actions (functions)
     setSearch,
     setShowAllParts,
     toggleShowAllParts,
     fetchUsers,
+    refreshUsers,
     toggleExpand,
     toggleAllBikes
   };

--- a/kor-react/src/components/shop/services/partReplaceApi.ts
+++ b/kor-react/src/components/shop/services/partReplaceApi.ts
@@ -1,0 +1,114 @@
+import { ADD_MILES_AMOUNT, ADD_HOURS_AMOUNT } from '../WearBar/wearUtils';
+
+const FORM_ENCODED = 'application/x-www-form-urlencoded';
+
+const postJson = async (url: string, body: Record<string, unknown>): Promise<any> => {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    redirect: 'follow' as RequestRedirect,
+  });
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  const data = await response.json();
+  if (data?.message !== 'success') throw new Error(data?.error || 'Request failed');
+  return data;
+};
+
+const postForm = async (url: string, body: Record<string, string>): Promise<any> => {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': FORM_ENCODED },
+    body: new URLSearchParams(body) as unknown as BodyInit,
+    redirect: 'follow' as RequestRedirect,
+  });
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  const data = await response.json();
+  if (data?.message !== 'success') throw new Error(data?.error || 'Request failed');
+  return data;
+};
+
+// ---------------------------------------------------------------------------
+// replacePart
+// ---------------------------------------------------------------------------
+
+export interface ReplacePartParams {
+  baseUrl: string;
+  stravaUserId: string | number;
+  stravaWearBikeId: string | number;
+  bikeName: string;
+  replaceEndpoint: string;
+  usedBodyKey: string;
+  partType: string;
+  usedAmount: number;
+  brokenWorn: 'worn_out' | 'broke';
+  extraBody?: Record<string, string>;
+}
+
+/**
+ * Resets part mileage to 0 and logs the replacement in part history.
+ */
+export const replacePart = async (params: ReplacePartParams): Promise<void> => {
+  const {
+    baseUrl,
+    stravaUserId,
+    stravaWearBikeId,
+    bikeName,
+    replaceEndpoint,
+    usedBodyKey,
+    partType,
+    usedAmount,
+    brokenWorn,
+    extraBody,
+  } = params;
+
+  // 1. Reset the part's used miles/hours to 0
+  await postForm(`${baseUrl}${replaceEndpoint}`, {
+    strava_user_id: String(stravaUserId),
+    strava_bike_id: String(stravaWearBikeId),
+    [usedBodyKey]: '0',
+    ...extraBody,
+  });
+
+  // 2. Log replacement in history
+  await postForm(`${baseUrl}/updatePartHistory`, {
+    strava_user_id: String(stravaUserId),
+    strava_bike_id: String(stravaWearBikeId),
+    part_type: partType,
+    model: '',
+    used_miles: String(usedAmount),
+    broken_worn: brokenWorn,
+    bike_type: 'Bike',
+  });
+};
+
+// ---------------------------------------------------------------------------
+// addMileage
+// ---------------------------------------------------------------------------
+
+export interface AddMileageParams {
+  baseUrl: string;
+  stravaUserId: string | number;
+  bikeId: string | number;
+  bikeName: string;
+  partType: string;
+  usedBodyKey: string;
+  unit: 'miles' | 'hours';
+}
+
+/**
+ * Adds a fixed amount (100 miles or 100 hours) to a part's used total.
+ */
+export const addMileage = async (params: AddMileageParams): Promise<void> => {
+  const { baseUrl, stravaUserId, bikeId, bikeName, partType, usedBodyKey, unit } = params;
+  const increase = unit === 'hours' ? ADD_HOURS_AMOUNT : ADD_MILES_AMOUNT;
+
+  await postJson(`${baseUrl}/addMileage`, {
+    part_type: partType,
+    used_body_key: usedBodyKey,
+    bike_name: bikeName,
+    strava_user_id: String(stravaUserId),
+    bike_id: String(bikeId),
+    increase,
+  });
+};

--- a/kor-react/src/components/shop/services/shopMaintenanceApi.ts
+++ b/kor-react/src/components/shop/services/shopMaintenanceApi.ts
@@ -12,6 +12,7 @@
 import { convertApiResponse } from '../modules/dataConverter';
 
 const FORM_ENCODED = 'application/x-www-form-urlencoded';
+const API_SUCCESS = 'success';
 
 export interface FetchConfig {
   baseUrl: string;
@@ -85,7 +86,7 @@ export const fetchShopMaintenanceReports = async (
 
   const data = await response.json();
 
-  if (data?.message !== 'success' || !Array.isArray(data?.users)) {
+  if (data?.message !== API_SUCCESS || !Array.isArray(data?.users)) {
     throw new Error(data?.error || 'Unexpected response from server');
   }
 
@@ -123,7 +124,7 @@ export const fetchShopUsers = async (
 
   const data = await response.json();
 
-  if (data?.message !== 'success' || !Array.isArray(data?.users)) {
+  if (data?.message !== API_SUCCESS || !Array.isArray(data?.users)) {
     throw new Error(data?.error || 'Unexpected response when loading users');
   }
 
@@ -159,7 +160,7 @@ export const removeUserShop = async (
 
   const data = (await response.json()) as RemoveUserShopResponse;
 
-  if (data?.message !== 'success') {
+  if (data?.message !== API_SUCCESS) {
     throw new Error(data?.error || data?.message || 'Failed to remove user');
   }
 
@@ -198,7 +199,7 @@ export const setUserHead = async (
 
   const data = (await response.json()) as SetUserHeadResponse;
 
-  if (data?.message !== 'success') {
+  if (data?.message !== API_SUCCESS) {
     throw new Error(data?.error || data?.message || 'Failed to set user as admin');
   }
 
@@ -252,7 +253,7 @@ export const getShopHead = async (config: FetchConfig): Promise<ShopHeadData | n
 
   const data = (await response.json()) as GetShopHeadResponse;
 
-  if (data?.message !== 'success') {
+  if (data?.message !== API_SUCCESS) {
     throw new Error(data?.error || 'Failed to get shop head');
   }
 

--- a/kor-react/src/components/shop/styles/partReplaceModal.styles.ts
+++ b/kor-react/src/components/shop/styles/partReplaceModal.styles.ts
@@ -1,0 +1,152 @@
+// Styles for the Part Replace / Add Mileage modal.
+// Plain style objects — same pattern as userManagementModal.styles.ts.
+
+export const overlayStyle: React.CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  backgroundColor: 'rgba(0,0,0,0.4)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 1000,
+};
+
+export const contentStyle: React.CSSProperties = {
+  backgroundColor: '#ffffff',
+  borderRadius: 10,
+  padding: '1.5rem',
+  width: '90%',
+  maxWidth: 400,
+  boxShadow: '0 12px 40px rgba(0,0,0,0.18)',
+  position: 'relative',
+};
+
+export const titleRowStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  marginBottom: '0.75rem',
+};
+
+export const titleStyle: React.CSSProperties = {
+  margin: 0,
+  fontSize: '1.15rem',
+  fontWeight: 700,
+  color: '#1f2937',
+};
+
+export const closeButtonStyle: React.CSSProperties = {
+  background: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  color: '#6b7280',
+  padding: 4,
+  borderRadius: 6,
+};
+
+export const wornTextStyle: React.CSSProperties = {
+  margin: 0,
+  fontSize: '0.95rem',
+  color: '#4b5563',
+  marginBottom: '0.25rem',
+};
+
+export const dateTextStyle: React.CSSProperties = {
+  margin: 0,
+  fontSize: '0.85rem',
+  color: '#9ca3af',
+  marginBottom: '1rem',
+};
+
+export const questionStyle: React.CSSProperties = {
+  margin: 0,
+  fontSize: '0.95rem',
+  color: '#374151',
+  fontWeight: 500,
+  marginBottom: '0.75rem',
+};
+
+export const buttonRowStyle: React.CSSProperties = {
+  display: 'flex',
+  gap: '0.5rem',
+  marginBottom: '1rem',
+};
+
+export const primaryButtonStyle: React.CSSProperties = {
+  flex: 1,
+  border: 'none',
+  borderRadius: 6,
+  padding: '0.5rem 1rem',
+  fontSize: '0.9rem',
+  cursor: 'pointer',
+  backgroundColor: '#3B82F6',
+  color: '#ffffff',
+  fontWeight: 600,
+};
+
+export const secondaryButtonStyle: React.CSSProperties = {
+  flex: 1,
+  border: 'none',
+  borderRadius: 6,
+  padding: '0.5rem 1rem',
+  fontSize: '0.9rem',
+  cursor: 'pointer',
+  backgroundColor: '#f0f0f0',
+  color: '#333333',
+  fontWeight: 500,
+};
+
+export const dangerButtonStyle: React.CSSProperties = {
+  ...primaryButtonStyle,
+  backgroundColor: '#FF1744',
+};
+
+export const dividerStyle: React.CSSProperties = {
+  borderTop: '1px solid #e5e7eb',
+  marginBottom: '0.75rem',
+};
+
+export const addButtonStyle: React.CSSProperties = {
+  width: '100%',
+  border: '1px solid #e5e7eb',
+  borderRadius: 6,
+  padding: '0.5rem 1rem',
+  fontSize: '0.9rem',
+  cursor: 'pointer',
+  backgroundColor: 'transparent',
+  color: '#374151',
+  fontWeight: 500,
+};
+
+export const errorStyle: React.CSSProperties = {
+  backgroundColor: '#ffe6e6',
+  color: '#c0392b',
+  padding: '0.5rem 0.75rem',
+  borderRadius: 4,
+  fontSize: '0.85rem',
+  marginBottom: '0.75rem',
+};
+
+export const successContainerStyle: React.CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: '2rem 1rem',
+  gap: '0.5rem',
+};
+
+export const successTextStyle: React.CSSProperties = {
+  fontSize: '1.1rem',
+  fontWeight: 600,
+  color: '#16a34a',
+};
+
+export const disabledButtonStyle = (base: React.CSSProperties): React.CSSProperties => ({
+  ...base,
+  opacity: 0.6,
+  cursor: 'not-allowed',
+});

--- a/kor-react/src/components/shop/styles/userManagementModal.styles.ts
+++ b/kor-react/src/components/shop/styles/userManagementModal.styles.ts
@@ -1,6 +1,53 @@
 // Styles for the family plan user management modal and confirm delete modal
 // Kept in plain objects for easy reuse and maintainability.
 
+import { tokens } from './shopMaintenance.styles';
+
+/**
+ * Modal-specific design tokens.
+ * Extends the shared token system with colors unique to this modal.
+ */
+const modalTokens = {
+  colors: {
+    // Text
+    textHeading: '#1f2937',
+    textBody: '#374151',
+    textMuted: '#4b5563',
+    textDisabled: '#9ca3af',
+    textDanger: '#dc2626',
+    textDangerDark: '#c0392b',
+    textWarning: '#f39c12',
+    // Backgrounds
+    bgSubtle: '#f3f4f6',
+    bgDisabled: '#f9fafb',
+    bgError: '#ffe6e6',
+    bgDangerDisabled: '#f5b7b1',
+    bgSecondaryButton: '#e0e0e0',
+    // Borders
+    borderSubtle: '#e5e7eb',
+    borderDivider: '#eef0f3',
+    borderDividerLight: '#f1f5f9',
+    borderDanger: '#fee2e2',
+    // Blue (primary action / admin indicator)
+    blue: '#3B82F6',
+    blueDark: '#1d4ed8',
+    blueBorder: '#dbeafe',
+    blueSubtle: '#eff6ff',
+    blueLegendBg: '#f0f7ff',
+    // Tab active text
+    textTabActive: '#111827',
+    textTabInactive: '#6b7280',
+  },
+  zIndex: {
+    modal: 1000,
+  },
+  size: {
+    closeButton: 34,
+    deleteButton: 36,
+    adminIndicatorDot: 8,
+  },
+};
+
 export const modalOverlayStyle: React.CSSProperties = {
   position: 'fixed',
   top: 0,
@@ -11,12 +58,12 @@ export const modalOverlayStyle: React.CSSProperties = {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  zIndex: 1000,
+  zIndex: modalTokens.zIndex.modal,
 };
 
 export const modalContentStyle: React.CSSProperties = {
-  backgroundColor: '#ffffff',
-  borderRadius: 10,
+  backgroundColor: tokens.colors.white,
+  borderRadius: tokens.borderRadius.md,
   padding: '1.25rem',
   width: '100%',
   maxWidth: 560,
@@ -27,23 +74,23 @@ export const modalTitleRowStyle: React.CSSProperties = {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'space-between',
-  gap: '0.75rem',
+  gap: tokens.spacing.sm,
 };
 
 export const modalHeaderStyle: React.CSSProperties = {
   margin: 0,
   fontSize: '1.15rem',
   fontWeight: 700,
-  color: '#1f2937',
+  color: modalTokens.colors.textHeading,
 };
 
 export const closeIconButtonStyle: React.CSSProperties = {
-  border: '1px solid #e5e7eb',
-  backgroundColor: '#ffffff',
-  color: '#374151',
-  borderRadius: 8,
-  width: 34,
-  height: 34,
+  border: `1px solid ${modalTokens.colors.borderSubtle}`,
+  backgroundColor: tokens.colors.white,
+  color: modalTokens.colors.textBody,
+  borderRadius: tokens.borderRadius.sm,
+  width: modalTokens.size.closeButton,
+  height: modalTokens.size.closeButton,
   display: 'inline-flex',
   alignItems: 'center',
   justifyContent: 'center',
@@ -53,7 +100,7 @@ export const closeIconButtonStyle: React.CSSProperties = {
 export const tabsContainerStyle: React.CSSProperties = {
   display: 'flex',
   marginTop: '0.9rem',
-  borderBottom: '1px solid #eef0f3',
+  borderBottom: `1px solid ${modalTokens.colors.borderDivider}`,
 };
 
 export const tabButtonStyle = (active: boolean): React.CSSProperties => ({
@@ -63,38 +110,38 @@ export const tabButtonStyle = (active: boolean): React.CSSProperties => ({
   cursor: 'pointer',
   fontSize: '0.9rem',
   fontWeight: active ? 600 : 500,
-  color: active ? '#111827' : '#6b7280',
-  borderBottom: active ? '2px solid #3B82F6' : '2px solid transparent',
+  color: active ? modalTokens.colors.textTabActive : modalTokens.colors.textTabInactive,
+  borderBottom: active ? `2px solid ${modalTokens.colors.blue}` : '2px solid transparent',
   marginBottom: -1,
 });
 
 export const tabPanelStyle: React.CSSProperties = {
-  paddingTop: '1rem',
+  paddingTop: tokens.spacing.md,
 };
 
 export const modalSubtextStyle: React.CSSProperties = {
   margin: 0,
   marginBottom: '0.9rem',
   fontSize: '0.9rem',
-  color: '#4b5563',
+  color: modalTokens.colors.textMuted,
   lineHeight: 1.4,
 };
 
 export const infoNoticeStyle: React.CSSProperties = {
-  backgroundColor: '#f3f4f6',
-  border: '1px solid #e5e7eb',
-  color: '#374151',
+  backgroundColor: modalTokens.colors.bgSubtle,
+  border: `1px solid ${modalTokens.colors.borderSubtle}`,
+  color: modalTokens.colors.textBody,
   padding: '0.6rem 0.75rem',
-  borderRadius: 8,
+  borderRadius: tokens.borderRadius.sm,
   fontSize: '0.85rem',
-  marginBottom: '0.75rem',
+  marginBottom: tokens.spacing.sm,
 };
 
 export const userListContainerStyle: React.CSSProperties = {
   maxHeight: 320,
   overflowY: 'auto',
-  marginTop: '0.5rem',
-  marginBottom: '1rem',
+  marginTop: tokens.spacing.xs,
+  marginBottom: tokens.spacing.md,
 };
 
 export const userListItemStyle: React.CSSProperties = {
@@ -102,8 +149,8 @@ export const userListItemStyle: React.CSSProperties = {
   alignItems: 'center',
   justifyContent: 'space-between',
   padding: '0.65rem 0.25rem',
-  borderBottom: '1px solid #f1f5f9',
-  gap: '0.75rem',
+  borderBottom: `1px solid ${modalTokens.colors.borderDividerLight}`,
+  gap: tokens.spacing.sm,
 };
 
 export const userListInfoStyle: React.CSSProperties = {
@@ -117,14 +164,14 @@ export const userListInfoStyle: React.CSSProperties = {
 export const userListNameRowStyle: React.CSSProperties = {
   display: 'flex',
   alignItems: 'center',
-  gap: '0.5rem',
+  gap: tokens.spacing.xs,
   minWidth: 0,
 };
 
 export const userListNameStyle: React.CSSProperties = {
   fontSize: '0.95rem',
   fontWeight: 600,
-  color: '#111827',
+  color: modalTokens.colors.textTabActive,
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   whiteSpace: 'nowrap',
@@ -134,9 +181,9 @@ export const adminBadgeStyle: React.CSSProperties = {
   display: 'inline-flex',
   alignItems: 'center',
   gap: 6,
-  border: '1px solid #dbeafe',
-  backgroundColor: '#eff6ff',
-  color: '#1d4ed8',
+  border: `1px solid ${modalTokens.colors.blueBorder}`,
+  backgroundColor: modalTokens.colors.blueSubtle,
+  color: modalTokens.colors.blueDark,
   padding: '0.15rem 0.45rem',
   borderRadius: 999,
   fontSize: '0.75rem',
@@ -146,16 +193,16 @@ export const adminBadgeStyle: React.CSSProperties = {
 
 export const userListEmailStyle: React.CSSProperties = {
   fontSize: '0.85rem',
-  color: '#666',
+  color: tokens.colors.textSecondary,
 };
 
 export const deleteButtonStyle = (disabled: boolean): React.CSSProperties => ({
-  border: '1px solid #fee2e2',
-  backgroundColor: disabled ? '#f9fafb' : '#ffffff',
-  color: disabled ? '#9ca3af' : '#dc2626',
-  borderRadius: 10,
-  width: 36,
-  height: 36,
+  border: `1px solid ${modalTokens.colors.borderDanger}`,
+  backgroundColor: disabled ? modalTokens.colors.bgDisabled : tokens.colors.white,
+  color: disabled ? modalTokens.colors.textDisabled : modalTokens.colors.textDanger,
+  borderRadius: tokens.borderRadius.md,
+  width: modalTokens.size.deleteButton,
+  height: modalTokens.size.deleteButton,
   display: 'inline-flex',
   alignItems: 'center',
   justifyContent: 'center',
@@ -165,7 +212,7 @@ export const deleteButtonStyle = (disabled: boolean): React.CSSProperties => ({
 export const modalFooterStyle: React.CSSProperties = {
   display: 'flex',
   justifyContent: 'flex-end',
-  marginTop: '0.75rem',
+  marginTop: tokens.spacing.sm,
 };
 
 export const modalButtonStyle = (
@@ -176,30 +223,30 @@ export const modalButtonStyle = (
   padding: '0.5rem 1.1rem',
   fontSize: '0.9rem',
   cursor: 'pointer',
-  backgroundColor: variant === 'primary' ? '#3B82F6' : '#e0e0e0',
-  color: variant === 'primary' ? '#ffffff' : '#333333',
-  marginLeft: '0.5rem',
+  backgroundColor: variant === 'primary' ? modalTokens.colors.blue : modalTokens.colors.bgSecondaryButton,
+  color: variant === 'primary' ? tokens.colors.white : tokens.colors.textPrimary,
+  marginLeft: tokens.spacing.xs,
 });
 
 export const errorMessageStyle: React.CSSProperties = {
-  backgroundColor: '#ffe6e6',
-  color: '#c0392b',
-  padding: '0.5rem 0.75rem',
+  backgroundColor: modalTokens.colors.bgError,
+  color: modalTokens.colors.textDangerDark,
+  padding: `${tokens.spacing.xs} ${tokens.spacing.sm}`,
   borderRadius: 4,
   fontSize: '0.85rem',
-  marginBottom: '0.75rem',
+  marginBottom: tokens.spacing.sm,
 };
 
 export const emptyStateStyle: React.CSSProperties = {
   textAlign: 'center',
   padding: '1rem 0.5rem',
   fontSize: '0.9rem',
-  color: '#6b7280',
+  color: modalTokens.colors.textTabInactive,
 };
 
 export const unsavedChangesBadgeStyle: React.CSSProperties = {
-  color: '#f39c12',
-  marginLeft: '0.5rem',
+  color: modalTokens.colors.textWarning,
+  marginLeft: tokens.spacing.xs,
 };
 
 export const adminInnerStyle: React.CSSProperties = {
@@ -209,8 +256,8 @@ export const adminInnerStyle: React.CSSProperties = {
 export const adminFooterStyle: React.CSSProperties = {
   display: 'flex',
   justifyContent: 'flex-end',
-  marginTop: '0.75rem',
-  gap: '0.5rem',
+  marginTop: tokens.spacing.sm,
+  gap: tokens.spacing.xs,
 };
 
 // Admin settings tab styles
@@ -218,7 +265,7 @@ export const adminFooterStyle: React.CSSProperties = {
 export const adminListContainerStyle: React.CSSProperties = {
   display: 'flex',
   flexDirection: 'column',
-  gap: '0.5rem',
+  gap: tokens.spacing.xs,
   maxHeight: 320,
   overflowY: 'auto',
   paddingRight: 2,
@@ -228,10 +275,10 @@ export const adminListItemStyle: React.CSSProperties = {
   display: 'grid',
   gridTemplateColumns: '18px 1fr auto',
   alignItems: 'center',
-  gap: '0.75rem',
+  gap: tokens.spacing.sm,
   padding: '0.65rem 0.75rem',
-  border: '1px solid #eef0f3',
-  borderRadius: 10,
+  border: `1px solid ${modalTokens.colors.borderDivider}`,
+  borderRadius: tokens.borderRadius.md,
   cursor: 'pointer',
   userSelect: 'none',
 };
@@ -256,7 +303,7 @@ export const confirmModalContentStyle: React.CSSProperties = {
 
 export const confirmModalHeaderStyle: React.CSSProperties = {
   ...modalHeaderStyle,
-  marginBottom: '0.75rem',
+  marginBottom: tokens.spacing.sm,
 };
 
 export const confirmModalTextStyle: React.CSSProperties = {
@@ -267,7 +314,7 @@ export const confirmModalTextStyle: React.CSSProperties = {
 export const confirmModalFooterStyle: React.CSSProperties = {
   display: 'flex',
   justifyContent: 'flex-end',
-  gap: '0.5rem',
+  gap: tokens.spacing.xs,
 };
 
 export const confirmButtonStyle = (
@@ -282,8 +329,8 @@ export const confirmButtonStyle = (
   backgroundColor:
     variant === 'danger'
       ? disabled
-        ? '#f5b7b1'
-        : '#e74c3c'
-      : '#e0e0e0',
-  color: variant === 'danger' ? '#ffffff' : '#333333',
+        ? modalTokens.colors.bgDangerDisabled
+        : tokens.colors.error
+      : modalTokens.colors.bgSecondaryButton,
+  color: variant === 'danger' ? tokens.colors.white : tokens.colors.textPrimary,
 });


### PR DESCRIPTION
Context: The shop maintenance view shows wear bars for every part on every customer's bike. This PR adds the ability to act on that data — shop staff can click a part to mark it as replaced or manually add mileage.

What changed
New: PartReplaceModal — click any wear bar to open a modal showing the part's current wear, last replaced date, and two actions:

Mark as replaced — resets usage to 0 via the existing part endpoints (/newChain, /newCassette, etc.) and logs it to part history via /updatePartHistory
Add mileage/hours — increments the part's usage by a fixed amount via /addMileage
Refactor: PART_CONFIGS — replaced the hardcoded buildPartsForBike array with a single config table in partWear.ts. Each entry declares the part's label, icon, unit, API endpoint, and body key. This is what drives the modal — no per-part branching logic needed.

New: partReplaceApi.ts — replacePart and addMileage API functions, extracted into their own file to keep the growing shopMaintenanceApi.ts focused.

Bug fix: rearShockService was being sent rear_shock_used_miles but the backend reads rear_shock_used_hours. Fixed in PART_CONFIGS.