### PR TITLE
Family plan part replacement: confirmation step in PartReplaceModal

### DIFF
--- a/kor-react/src/components/shop/WearBar/PartReplaceModal.tsx
+++ b/kor-react/src/components/shop/WearBar/PartReplaceModal.tsx
@@ -48,8 +48,12 @@ interface PartReplaceModalProps {
   onSuccess: () => void;
 }
 
-type ModalState = 'idle' | 'loading' | 'success' | 'error';
+type ModalState = 'idle' | 'confirming' | 'loading' | 'success' | 'error';
 type SuccessAction = 'replaced' | 'mileage_added' | null;
+type PendingAction =
+  | { type: 'replace'; brokenWorn: 'worn_out' | 'broke' }
+  | { type: 'addMileage' }
+  | null;
 
 const PartReplaceModal: React.FC<PartReplaceModalProps> = ({
   isOpen,
@@ -60,19 +64,26 @@ const PartReplaceModal: React.FC<PartReplaceModalProps> = ({
   const [modalState, setModalState] = useState<ModalState>('idle');
   const [errorMessage, setErrorMessage] = useState('');
   const [successAction, setSuccessAction] = useState<SuccessAction>(null);
+  const [pendingAction, setPendingAction] = useState<PendingAction>(null);
 
   useEffect(() => {
     if (isOpen) {
       setModalState('idle');
       setErrorMessage('');
       setSuccessAction(null);
+      setPendingAction(null);
     }
   }, [isOpen]);
+
 
   if (!part || !isOpen) return null;
 
   const chainLike = isChainLike(part.label);
   const loading = modalState === 'loading';
+
+  const confirmMessage = pendingAction?.type === 'addMileage'
+    ? `Are you sure you want to add ${part.unit === 'hours' ? `${ADD_HOURS_AMOUNT} hours` : `${ADD_MILES_AMOUNT} miles`}?`
+    : `Are you sure you want to replace this part?`;
   const formattedDate = formatReplacedDate(part.lastReplacedDate);
   const addLabel = part.unit === 'hours'
     ? `Add ${ADD_HOURS_AMOUNT} Hours`
@@ -81,9 +92,7 @@ const PartReplaceModal: React.FC<PartReplaceModalProps> = ({
   const handleSuccess = (action: SuccessAction) => {
     setSuccessAction(action);
     setModalState('success');
-    setTimeout(() => {
-      onSuccess();
-    }, 1500);
+    onSuccess();
   };
 
   const handleError = (err: unknown) => {
@@ -92,66 +101,89 @@ const PartReplaceModal: React.FC<PartReplaceModalProps> = ({
     setModalState('error');
   };
 
-  const handleReplace = async (brokenWorn: 'worn_out' | 'broke') => {
-    setModalState('loading');
-    setErrorMessage('');
-    try {
-      const { baseUrl } = getApiConfig();
-      const extraBody: Record<string, string> | undefined =
-        part.partType === 'sealant'
-          ? { sealant_hour_marker: String(Math.floor(Date.now() / 1000 / 60 / 60)) }
-          : undefined;
-
-      await replacePart({
-        baseUrl,
-        stravaUserId: part.ownerId,
-        stravaWearBikeId: part.bikeId,
-        bikeName: part.bikeName,
-        replaceEndpoint: part.replaceEndpoint,
-        usedBodyKey: part.usedBodyKey,
-        partType: part.partType,
-        usedAmount: part.usedAmount,
-        brokenWorn,
-        extraBody,
-      });
-      handleSuccess('replaced');
-    } catch (err) {
-      handleError(err);
-    }
+  const handleReplace = (brokenWorn: 'worn_out' | 'broke') => {
+    setPendingAction({ type: 'replace', brokenWorn });
+    setModalState('confirming');
   };
 
-  const handleAddMileage = async () => {
+  const handleAddMileage = () => {
+    setPendingAction({ type: 'addMileage' });
+    setModalState('confirming');
+  };
+
+  const handleCancelConfirm = () => {
+    setPendingAction(null);
+    setModalState('idle');
+  };
+
+  const handleConfirm = async () => {
+    if (!pendingAction) return;
     setModalState('loading');
     setErrorMessage('');
     try {
       const { baseUrl } = getApiConfig();
-      await addMileage({
-        baseUrl,
-        stravaUserId: part.ownerId,
-        bikeId: part.bikeId,
-        bikeName: part.bikeName,
-        partType: part.partType,
-        usedBodyKey: part.usedBodyKey,
-        unit: part.unit,
-      });
-      handleSuccess('mileage_added');
+      if (pendingAction.type === 'replace') {
+        const extraBody: Record<string, string> | undefined =
+          part.partType === 'sealant'
+            ? { sealant_hour_marker: String(Math.floor(Date.now() / 1000 / 60 / 60)) }
+            : undefined;
+        await replacePart({
+          baseUrl,
+          stravaUserId: part.ownerId,
+          stravaWearBikeId: part.bikeId,
+          bikeName: part.bikeName,
+          replaceEndpoint: part.replaceEndpoint,
+          usedBodyKey: part.usedBodyKey,
+          partType: part.partType,
+          usedAmount: part.usedAmount,
+          brokenWorn: pendingAction.brokenWorn,
+          extraBody,
+        });
+        handleSuccess('replaced');
+      } else {
+        await addMileage({
+          baseUrl,
+          stravaUserId: part.ownerId,
+          bikeId: part.bikeId,
+          bikeName: part.bikeName,
+          partType: part.partType,
+          usedBodyKey: part.usedBodyKey,
+          unit: part.unit,
+        });
+        handleSuccess('mileage_added');
+      }
     } catch (err) {
       handleError(err);
     }
   };
 
   const handleClose = () => {
-    if (loading) return;
+    if (loading || modalState === 'confirming') return;
     setModalState('idle');
     setErrorMessage('');
+    setPendingAction(null);
     onClose();
   };
 
   return (
     <div style={overlayStyle} onClick={handleClose}>
       <div style={contentStyle} onClick={e => e.stopPropagation()}>
-        {/* Success state */}
-        {modalState === 'success' ? (
+        {/* Confirmation state */}
+        {modalState === 'confirming' ? (
+          <div style={{ textAlign: 'center', padding: '1rem 0' }}>
+            <p style={{ ...questionStyle, fontSize: '1rem', marginBottom: '1.25rem' }}>
+              {confirmMessage}
+            </p>
+            <div style={buttonRowStyle}>
+              <button style={primaryButtonStyle} onClick={handleConfirm}>
+                Yes
+              </button>
+              <button style={secondaryButtonStyle} onClick={handleCancelConfirm}>
+                Cancel
+              </button>
+            </div>
+          </div>
+        ) : modalState === 'success' ? (
           <div style={successContainerStyle}>
             <CheckCircle size={36} color="#16a34a" />
             <p style={successTextStyle}>


### PR DESCRIPTION
Adds a confirmation screen inside PartReplaceModal that appears after the user selects "Replace Part" or "Add Miles/Hours", asking "Are you sure?" before executing the API call. Includes a fix to block accidental dismissal via overlay click while confirming.