### PR TITLE
Add GitHub Actions workflow: auto-deploy to production on merge

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,121 @@
+name: Deploy to Production
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Build & Deploy React App
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: kor-react/package-lock.json
+
+      - name: Install dependencies
+        working-directory: kor-react
+        run: npm ci
+
+      - name: Build React app
+        working-directory: kor-react
+        env:
+          NODE_ENV: production
+        run: npm run build
+
+      - name: Verify build output
+        run: |
+          if [ ! -d "kor-react/build" ]; then
+            echo "ERROR: Build directory not found" >&2
+            exit 1
+          fi
+          if [ ! -f "oauth/authorize/index.html" ]; then
+            echo "ERROR: Missing legacy oauth/authorize/index.html" >&2
+            exit 1
+          fi
+
+      - name: Set up SSH
+        env:
+          DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+        run: |
+          install -m 700 -d ~/.ssh
+          echo "$DEPLOY_SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H jmrcycling.com >> ~/.ssh/known_hosts
+
+      - name: Prepare remote directories
+        run: |
+          ssh root@jmrcycling.com \
+            "mkdir -p /var/www/jmrcycling.com /var/www/jmrcycling.com/oauth/authorize"
+
+      - name: Create remote backup
+        run: |
+          TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+          ssh root@jmrcycling.com \
+            "tar -C /var/www/jmrcycling.com -czf /var/www/jmrcycling.com/backup-${TIMESTAMP}.tgz . || true"
+
+      - name: Deploy build (rsync, preserve oauth/)
+        run: |
+          rsync -az --delete --exclude 'oauth/' \
+            -e "ssh -o StrictHostKeyChecking=no" \
+            kor-react/build/ root@jmrcycling.com:/var/www/jmrcycling.com/
+
+      - name: Deploy legacy oauth/authorize
+        run: |
+          rsync -az \
+            -e "ssh -o StrictHostKeyChecking=no" \
+            oauth/authorize/ root@jmrcycling.com:/var/www/jmrcycling.com/oauth/authorize/
+
+      - name: Health checks
+        run: |
+          ROUTES=(
+            "https://jmrcycling.com/"
+            "https://jmrcycling.com/shop/login"
+            "https://jmrcycling.com/shop/dashboard"
+            "https://jmrcycling.com/our-app"
+            "https://jmrcycling.com/contact"
+            "https://jmrcycling.com/oauth/authorize/"
+          )
+
+          FAILED=false
+
+          for route in "${ROUTES[@]}"; do
+            if curl -sf --max-time 10 "$route" > /dev/null; then
+              echo "OK  $route"
+            else
+              echo "FAIL $route" >&2
+              FAILED=true
+            fi
+          done
+
+          # Content check: React root in SPA route
+          if curl -s --max-time 10 "https://jmrcycling.com/oauth/authorize/" | grep -q '<div id="root">'; then
+            echo "OK  /oauth/authorize/ serves React SPA shell"
+          else
+            echo "WARN /oauth/authorize/ — React root not found" >&2
+            FAILED=true
+          fi
+
+          # Content check: legacy static page marker
+          if curl -s --max-time 10 "https://jmrcycling.com/oauth/authorize/index.html" | grep -qi "Connecting to KOR"; then
+            echo "OK  /oauth/authorize/index.html legacy page present"
+          else
+            echo "WARN /oauth/authorize/index.html — marker text not found" >&2
+          fi
+
+          if [ "$FAILED" = "true" ]; then
+            echo ""
+            echo "One or more health checks failed. Check nginx SPA fallback config." >&2
+            exit 1
+          fi
+
+          echo ""
+          echo "All health checks passed. Live at https://jmrcycling.com/"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/deploy-production.yml` — a GitHub Actions workflow that fires on every push to `main` (i.e., every merged PR) and automates the steps currently performed manually by `deploy-react.sh`.

## What changed

Previously, production deployments required running `./deploy-react.sh` manually from a local machine. This workflow automates that entirely.

The workflow mirrors `deploy-react.sh` step-for-step:
1. `npm ci` + `npm run build` (`NODE_ENV=production`) inside `kor-react/`
2. Writes `DEPLOY_SSH_PRIVATE_KEY` secret to `~/.ssh/id_rsa`; uses `ssh-keyscan` for host verification
3. SSHs in to create `/var/www/jmrcycling.com` and `/oauth/authorize` dirs
4. Creates a timestamped `.tgz` backup on the remote server
5. `rsync -az --delete --exclude 'oauth/'` — syncs the React build, deletes stale files, preserves `oauth/`
6. `rsync -az` — syncs `oauth/authorize/` separately to keep the legacy static page
7. `curl` health checks on 6 routes (`/`, `/shop/login`, `/shop/dashboard`, `/our-app`, `/contact`, `/oauth/authorize/`)
8. Content checks: React root present at `/oauth/authorize/`, legacy marker text at `/oauth/authorize/index.html`

## Before merging

Add one repository secret under **Settings → Secrets and variables → Actions**:

| Secret | Value |
|---|---|
| `DEPLOY_SSH_PRIVATE_KEY` | Private SSH key whose public half is in `root@jmrcycling.com:~/.ssh/authorized_keys` |

No other secrets are needed — `kor-react/.env.production` is already committed and CRA picks it up at build time.

## Reviewer notes

- The `oauth/` exclude + explicit re-sync pattern is intentional — it preserves the legacy `oauth/authorize/index.html` through the `--delete` rsync pass
- Articles feature (`feature/seo-phase-1-infrastructure`) is not yet merged; when it lands it will be included automatically since it compiles into the React build

🤖 Generated with [Claude Code](https://claude.com/claude-code)