### PR TITLE
Fix deploy: correct SSH secret name and key writing

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -44,10 +44,10 @@ jobs:
 
       - name: Set up SSH
         env:
-          DEPLOY_SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         run: |
           install -m 700 -d ~/.ssh
-          echo "$DEPLOY_SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan -H jmrcycling.com >> ~/.ssh/known_hosts
 


### PR DESCRIPTION
## Summary

Fixes the SSH setup step in `.github/workflows/deploy-production.yml` that was causing `Permission denied (publickey)`.

## Two changes

**1. Wrong secret name**
The workflow referenced `secrets.DEPLOY_SSH_PRIVATE_KEY` but the secret in the repo is named `SSH_PRIVATE_KEY`.

**2. Key writing method**
Replaced `echo` with `printf '%s\n'` — `echo` can silently collapse the newlines inside a PEM key, producing a malformed file that OpenSSH rejects with `error in libcrypto`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)