### PR TITLE
chore: update caniuse-lite browserslist database

### DIFF
--- a/kor-react/package-lock.json
+++ b/kor-react/package-lock.json
@@ -6071,9 +6071,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001737",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001737.tgz",
-      "integrity": "sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw==",
+      "version": "1.0.30001797",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
+      "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
Silences the "browsers data is 10 months old" warning that appeared on every CI and deploy build run.

Also serves as a clean test merge to verify the SSH key and deploy workflow are working end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)