### PR TITLE
fix: improve contrast on articles page header and card text

### DIFF
--- a/kor-react/src/styles/styles.css
+++ b/kor-react/src/styles/styles.css
@@ -1857,6 +1857,7 @@ a.payment-card2, a.payment-card3 {
 .articles-index-header h1 {
   font-size: 2.8rem;
   margin-bottom: 0.5rem;
+  color: var(--headline-color-on-white, #110B11);
 }
 
 .articles-index-subtitle {
@@ -1914,7 +1915,7 @@ a.payment-card2, a.payment-card3 {
   border-radius: 10px;
   overflow: hidden;
   text-decoration: none;
-  color: inherit;
+  color: #fff;
   background: var(--card-bg, #1a1a1a);
   transition: transform 0.18s, box-shadow 0.18s;
   box-shadow: 0 2px 8px rgba(0,0,0,0.25);


### PR DESCRIPTION
## Summary

- **Articles header h1**: The global `h1` rule forces `color: white`, which was near-invisible on the light articles page background. Added a color override on `.articles-index-header h1` using `--headline-color-on-white` (`#110B11`).
- **Article card text**: Cards use a dark `#1a1a1a` background via `--card-bg`, but `color: inherit` was pulling the page's black text color — black on near-black. Changed `.article-card` to `color: #fff` so all card text (title, description, read time) is readable.

## Test plan

- [ ] Visit `/articles` and confirm "Cycling Articles" heading is dark and legible
- [ ] Confirm card titles, descriptions, and read-time text are white on dark cards
- [ ] Confirm the orange "MAINTENANCE" category label is unchanged
- [ ] Check no regressions on other pages that use `.article-card`

🤖 Generated with [Claude Code](https://claude.com/claude-code)