### PR TITLE
chore: gitignore .claude/ dirs and remove duplicate CI workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ Thumbs.db
 *.swp
 *.swo
 
+# Claude Code session data
+.claude/
+
 # Package lock files - we commit package-lock.json for CI consistency
 # package-lock.json
 


### PR DESCRIPTION
## Summary

- Added `.claude/` to `.gitignore` — covers both root and `kor-react/.claude/` directories (Claude Code session data that should never be committed)
- Deleted `.github/workflows/ci 2.yml`, a space-named exact duplicate of `ci.yml`

> Note: This branch also contains the contrast fix from [#15](https://github.com/masontuft/KOR-Website/pull/15), which was merged separately. The diff against main will include those changes due to squash-merge hash divergence.

## Test plan

- [ ] Confirm `.claude/` no longer appears as untracked after cloning/branching
- [ ] Confirm only one `ci.yml` exists in `.github/workflows/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)