### PR TITLE
chore: SEO routine — set PR_CADENCE to per-article

### DIFF
--- a/SEO_CONTENT_ROUTINE.md
+++ b/SEO_CONTENT_ROUTINE.md
@@ -13,6 +13,7 @@
 ROUTINE_VERSION: 2026-06-10
 AUTOMATION_MODE: true
 WORKING_DIRECTORY: kor-react
+PR_CADENCE: per-article
 CURRENT_PHASE: 2
 CURRENT_ARTICLE: A5
 ARTICLES_COMPLETED_THIS_PHASE: 1
@@ -20,7 +21,9 @@ PHASE_STATUS: in_progress
 NEXT_ACTION: build-article
 ```
 
-**What the agent does next:** Build article A5 (when-to-replace-brake-rotors). Phase 2b in progress: A4 done (1/5). Remaining: A5, A6, A7, A8. After A8, create PR feature/seo-phase-2b-brakes-tires.
+> **PR_CADENCE: per-article** — After every article build, set `NEXT_ACTION: create-pr` regardless of batch size. The `BATCH_SIZES` check is skipped. Each PR covers exactly one article. Branch naming: `feature/seo-article-[slug]`.
+
+**What the agent does next:** Build article A5 (when-to-replace-brake-rotors), then create PR `feature/seo-article-when-to-replace-brake-rotors`.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds `PR_CADENCE: per-article` to the machine-readable CURRENT STATUS block in `SEO_CONTENT_ROUTINE.md`
- Overrides the batch-based PR logic — agent now creates a PR after every single article build instead of waiting for a full batch (4–8 articles) to complete
- Branch naming going forward: `feature/seo-article-[slug]`

## Why
Batch PRs meant 4–8 articles would accumulate before any review could happen. Per-article PRs keep each change small, reviewable, and independently mergeable.

https://claude.ai/code/session_01NCP1DUL5wNtVfkTa4baQ8Z

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCP1DUL5wNtVfkTa4baQ8Z)_