### PR TITLE
design: homepage visual upgrades + inner page polish

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,200 @@
+# KOR Design System
+
+> **Memorable thing:** "Your bike talked to you first."  
+> The site should feel like getting a smart mechanic's report before a big ride — precise, honest, grounded in the trail. Not a Silicon Valley app landing page.
+
+---
+
+## Color System
+
+```css
+:root {
+  /* Core palette */
+  --color-navy:    #2e4053;   /* primary brand — header, dark sections */
+  --color-orange:  #E8821A;   /* action — CTAs, alerts, primary buttons */
+  --color-green:   #678d58;   /* HEALTH STATUS ONLY — "Good" state in wear indicators */
+  --color-warn:    #E8511A;   /* WARN state — "Replace Soon" in wear indicators */
+
+  /* Surface scale */
+  --color-dark:    #0d1520;   /* near-black — dark section backgrounds */
+  --color-mid:     #1e2d3d;   /* slightly lighter dark surface */
+  --color-white:   #ffffff;
+  --color-off-white: #f4f4f2; /* cards, light section background */
+
+  /* Text */
+  --color-text-primary:  #111111;   /* body on white */
+  --color-text-muted:    #555555;   /* secondary body on white */
+  --color-text-on-dark:  #ffffff;
+  --color-text-on-dark-muted: rgba(255, 255, 255, 0.65);
+}
+```
+
+### Color rules
+
+- `--color-green` is reserved for **"Good" status** in wear indicators and progress bars. Never use it as generic paragraph text color on white — that was an accident in the original CSS, and it reads as unintentional.
+- `--color-orange` is for **actions and alerts only** — primary CTA buttons, "Replace Soon" warnings, links that need energy.
+- `--color-navy` is the anchor — header background, dark hero overlays, footer.
+- Remove `--accent1-color: #85ffc7`, `--nav-background-color: #fc4c02` — these are stray values that conflict with the palette.
+
+---
+
+## Typography
+
+```css
+:root {
+  --font-heading: 'League Gothic', sans-serif;
+  --font-body:    'Lato', Helvetica, sans-serif;
+}
+```
+
+### Scale
+
+| Use | Size | Weight | Font |
+|---|---|---|---|
+| Hero title | `clamp(3.5rem, 8vw, 7rem)` | normal (League Gothic is inherently heavy) | heading |
+| Section heading | `clamp(2rem, 4vw, 3.5rem)` | normal | heading |
+| Subheading | `1.25rem` | 600 | body |
+| Body | `1rem` | 400 | body |
+| Caption / label | `0.85rem` | 400–600 | body |
+
+### Typography rules
+
+- League Gothic at large sizes with **no letter-spacing** override. The font was designed to be used at display sizes — trust it.
+- NEVER wrap H1 text in a colored pill/box with `background-color`. Let the heading be type, not a badge.
+- Use a **text-shadow** (`0 2px 20px rgba(0,0,0,0.6)`) on headings that appear directly over photos.
+
+---
+
+## Spacing
+
+- Base unit: `8px`
+- Section vertical padding: `80px` desktop, `48px` mobile
+- Card padding: `24px` internal, `16px` gap between cards
+- Max content width: `1200px`, centered
+
+---
+
+## Components
+
+### Hero
+
+**What it should do:** Put the trail photo front and center with nearly nothing obscuring it. The title and store buttons float on the photo.
+
+**What to avoid:**
+- ❌ Semi-transparent dark box around the CTA (`rgba(0,0,0,0.4)` with `border-radius: 15px`)
+- ❌ Navy pill around H1 (`.title_box` pattern)
+- ❌ Bullet list of "Smart Tracking / Strava Integration / Proactive Alerts" in the hero — abstract, no user sees themselves in it
+
+**What to do instead:**
+- White League Gothic title directly on photo, text-shadow for legibility
+- App store buttons below the title, side-by-side (already correct)
+- Keep the parallax effect
+
+### Component Wear Demo (replaces "Why Choose KOR?")
+
+The biggest homepage upgrade: **show the product**. Three feature cards describing "Simple & Intuitive" tell nobody anything. A live component health readout shows the exact value KOR provides.
+
+Render three wear indicators with animated percentages:
+
+```
+Chain          ████████░░  81%   Replace Soon (orange)
+Brake Pads     ████░░░░░░  45%   Good (green)
+Cassette       ███░░░░░░░  28%   Good (green)
+```
+
+Use **ReactBits CountUp** to animate the percentages counting up as the section enters the viewport. Pair with `GlareHover` on the card container.
+
+Section header: **"Know before it fails."** (Not "Why Choose KOR?")
+
+### Stats Row (optional, high-impact)
+
+Between hero and features:
+
+```
+_________ rides synced   |   _________ components tracked   |   Free forever
+```
+
+Use ReactBits **CountUp** on the numbers. Background: ReactBits **DotField** at ~15% opacity in `--color-navy`. This feels like a technical readout — a mileage dashboard.
+
+### CTA Button
+
+```css
+.btn-primary {
+  background-color: var(--color-orange);
+  color: white;
+  padding: 14px 28px;
+  border-radius: 6px;
+  font-family: var(--font-heading);
+  font-size: 1.3rem;
+  letter-spacing: 0.03em;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+.btn-primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px rgba(232, 130, 26, 0.4);
+}
+```
+
+The personal plans link in the hero (`KOR's personal plans keep your maintenance dialed in...`) is currently a wall of text in a link. Replace with: **"Personal plans →"** as a secondary button or text link. Never use a paragraph as a CTA.
+
+### Cards / Feature Items
+
+- Use ReactBits **GlareHover** wrapper on any card that should feel premium
+- Corner radius: `8px` (not `20px` — rounding that aggressive feels consumer-app, not precision-tool)
+- Cards on dark background: `background-color: var(--color-mid)`, 1px border `rgba(255,255,255,0.08)`
+- Cards on white: `background-color: var(--color-off-white)`, box-shadow `0 2px 12px rgba(0,0,0,0.06)`
+
+### Header
+
+Current header is solid. Keep the dark navy, keep the logo left + nav center layout.
+
+One fix: the "Log In" link on the right should visually separate from nav links — add a subtle border or make it an outlined button so it's clear it's an auth action, not a nav link.
+
+### Footer
+
+Currently minimal to the point of being useless. Minimum required:
+- App store download links (iOS + Android) — the whole point of the site
+- Real social links (not placeholder `facebook.com`)
+- Navigation links: Articles, Our Story, FAQ, Contact
+- Copyright
+
+---
+
+## ReactBits Integration
+
+Install from the [ReactBits registry](https://reactbits.dev/get-started/installation):
+
+```bash
+npx shadcn@latest add https://reactbits.dev/r/<component-name>
+```
+
+### Approved components for KOR
+
+| Component | URL | Use case | Priority |
+|---|---|---|---|
+| CountUp | `/text-animations/count-up` | Wear percentages, stats row numbers | High |
+| SplitText | `/text-animations/split-text` | Hero headline animating in word-by-word | Medium |
+| GlareHover | `/animations/glare-hover` | Wraps feature cards for depth | Medium |
+| DotField | `/backgrounds/dot-field` | Stats section background, navy at 15% opacity | Medium |
+| ScrollReveal | `/text-animations/scroll-reveal` | Body copy entering on scroll in features section | Low |
+| ClickSpark | `/animations/click-spark` | Optional: spark on app store button click | Low |
+
+### Do not use
+
+These are visual gimmicks that fight the brand's "precision tool" feeling:
+- PixelTrail, GlitchText, AsciiText, Ballpit, Ribbons, MagicRings, GhostCursor
+
+---
+
+## What to build next
+
+Priority order — each is a standalone PR:
+
+1. **`fix/hero-title-pill`** — Remove `.title_box` navy background, replace with white League Gothic + text-shadow
+2. **`feat/component-wear-section`** — Replace "Why Choose KOR?" 3-card grid with animated component health demo using CountUp
+3. **`feat/footer-app-links`** — Add real App Store / Google Play buttons to footer, fix social links
+4. **`fix/css-token-cleanup`** — Remove stray CSS variables (`--accent1-color`, `--nav-background-color`, old duplicate `.parallax-container`), rename `--paragraph-color-on-white` to reserve green for status use only
+5. **`feat/stats-row`** — Add countup stats between hero and features with DotField background
+6. **`feat/reactbits-countup`** — Wire in CountUp to component wear percentages

--- a/kor-react/src/components/common/CountUp.tsx
+++ b/kor-react/src/components/common/CountUp.tsx
@@ -1,0 +1,49 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+interface CountUpProps {
+  to: number;
+  duration?: number;
+  suffix?: string;
+  className?: string;
+}
+
+const CountUp: React.FC<CountUpProps> = ({ to, duration = 1400, suffix = '', className }) => {
+  const [value, setValue] = useState(0);
+  const ref = useRef<HTMLSpanElement>(null);
+  const started = useRef(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !started.current) {
+          started.current = true;
+          const start = performance.now();
+          const tick = (now: number) => {
+            const elapsed = now - start;
+            const progress = Math.min(elapsed / duration, 1);
+            // ease-out cubic
+            const eased = 1 - Math.pow(1 - progress, 3);
+            setValue(Math.round(eased * to));
+            if (progress < 1) requestAnimationFrame(tick);
+          };
+          requestAnimationFrame(tick);
+        }
+      },
+      { threshold: 0.3 }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [to, duration]);
+
+  return (
+    <span ref={ref} className={className}>
+      {value}{suffix}
+    </span>
+  );
+};
+
+export default CountUp;

--- a/kor-react/src/components/common/DotField.tsx
+++ b/kor-react/src/components/common/DotField.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface DotFieldProps {
+  color?: string;
+  opacity?: number;
+  spacing?: number;
+  dotSize?: number;
+  className?: string;
+  style?: React.CSSProperties;
+}
+
+const DotField: React.FC<DotFieldProps> = ({
+  color = '255, 255, 255',
+  opacity = 0.15,
+  spacing = 22,
+  dotSize = 1.5,
+  className,
+  style,
+}) => (
+  <div
+    aria-hidden="true"
+    className={className}
+    style={{
+      position: 'absolute',
+      inset: 0,
+      pointerEvents: 'none',
+      backgroundImage: `radial-gradient(circle, rgba(${color}, ${opacity}) ${dotSize}px, transparent ${dotSize}px)`,
+      backgroundSize: `${spacing}px ${spacing}px`,
+      ...style,
+    }}
+  />
+);
+
+export default DotField;

--- a/kor-react/src/components/common/GlareHover.tsx
+++ b/kor-react/src/components/common/GlareHover.tsx
@@ -1,0 +1,64 @@
+import React, { useRef, useState, useCallback } from 'react';
+
+interface GlareHoverProps {
+  children: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+  glareColor?: string;
+  glareOpacity?: number;
+  glareSize?: number;
+}
+
+const GlareHover: React.FC<GlareHoverProps> = ({
+  children,
+  className,
+  style,
+  glareColor = '255, 255, 255',
+  glareOpacity = 0.18,
+  glareSize = 55,
+}) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [glare, setGlare] = useState<{ x: number; y: number; active: boolean }>({
+    x: 50,
+    y: 50,
+    active: false,
+  });
+
+  const handleMouseMove = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const el = ref.current;
+    if (!el) return;
+    const rect = el.getBoundingClientRect();
+    const x = ((e.clientX - rect.left) / rect.width) * 100;
+    const y = ((e.clientY - rect.top) / rect.height) * 100;
+    setGlare({ x, y, active: true });
+  }, []);
+
+  const handleMouseLeave = useCallback(() => {
+    setGlare(prev => ({ ...prev, active: false }));
+  }, []);
+
+  return (
+    <div
+      ref={ref}
+      className={className}
+      style={{ position: 'relative', overflow: 'hidden', ...style }}
+      onMouseMove={handleMouseMove}
+      onMouseLeave={handleMouseLeave}
+    >
+      {children}
+      <div
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          inset: 0,
+          pointerEvents: 'none',
+          background: `radial-gradient(circle at ${glare.x}% ${glare.y}%, rgba(${glareColor}, ${glare.active ? glareOpacity : 0}) 0%, transparent ${glareSize}%)`,
+          transition: glare.active ? 'none' : 'background 0.4s ease',
+          borderRadius: 'inherit',
+        }}
+      />
+    </div>
+  );
+};
+
+export default GlareHover;

--- a/kor-react/src/components/common/SplitText.tsx
+++ b/kor-react/src/components/common/SplitText.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+interface SplitTextProps {
+  text: string;
+  className?: string;
+  delay?: number;
+  duration?: number;
+  stagger?: number;
+  threshold?: number;
+}
+
+const SplitText: React.FC<SplitTextProps> = ({
+  text,
+  className,
+  delay = 0,
+  duration = 600,
+  stagger = 60,
+  threshold = 0.2,
+}) => {
+  const [visible, setVisible] = useState(false);
+  const ref = useRef<HTMLSpanElement>(null);
+  const words = text.split(' ');
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          observer.disconnect();
+        }
+      },
+      { threshold }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [threshold]);
+
+  return (
+    <span ref={ref} className={className} aria-label={text} style={{ display: 'block' }}>
+      {words.map((word, wi) => (
+        <span
+          key={wi}
+          style={{ display: 'inline-block', overflow: 'hidden', verticalAlign: 'bottom' }}
+        >
+          <span
+            style={{
+              display: 'inline-block',
+              transform: visible ? 'translateY(0)' : 'translateY(110%)',
+              opacity: visible ? 1 : 0,
+              transition: `transform ${duration}ms cubic-bezier(0.22, 1, 0.36, 1), opacity ${duration}ms ease`,
+              transitionDelay: `${delay + wi * stagger}ms`,
+              willChange: 'transform, opacity',
+            }}
+          >
+            {word}
+          </span>
+          {wi < words.length - 1 && (
+            <span style={{ display: 'inline-block', width: '0.28em' }} aria-hidden="true" />
+          )}
+        </span>
+      ))}
+    </span>
+  );
+};
+
+export default SplitText;

--- a/kor-react/src/components/pages/FAQ.tsx
+++ b/kor-react/src/components/pages/FAQ.tsx
@@ -1,42 +1,69 @@
 import React, { useState } from 'react';
 import StructuredData from '../common/StructuredData';
 
+const faqs = [
+  {
+    question: 'I just bought a used bike — how can I track it accurately?',
+    answer:
+      'The app has a "Part Settings" page where you can manually set the wear percentage for used parts. We recommend having a bike shop estimate the condition of your components for the most accurate tracking.',
+  },
+  {
+    question: 'Can I use this app without a shop?',
+    answer:
+      'Absolutely! You can use our free version or purchase a personal account plan. We do recommend getting a shop code from a participating bike shop — it unlocks additional features and enhanced support.',
+  },
+  {
+    question: 'I lost my personal account code before entering it in the app. What now?',
+    answer:
+      'No problem. Contact us via email with your account information and we\'ll help you retrieve your personal account code.',
+  },
+  {
+    question: 'What if I don\'t have every part — no dropper, no rear shock, etc.?',
+    answer:
+      'KOR is flexible. Use the bike settings page to customize which components you want to track based on your specific setup. You can easily add or remove suspension, dropper posts, tubeless sealant, and more.',
+  },
+  {
+    question: 'How does the QR code system work?',
+    answer:
+      'Bike shops can generate a QR code from their KOR dashboard. When a customer scans it, they\'re taken straight to the app store with the shop code pre-filled — zero friction onboarding.',
+  },
+];
+
 const FAQ: React.FC = () => {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
   const [formData, setFormData] = useState({
     name: '',
     email: '',
-    question: ''
+    question: '',
   });
-
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitMessage, setSubmitMessage] = useState('');
 
   const baseUrl = process.env.REACT_APP_SITE_URL || 'https://jmrcycling.com';
 
+  const toggle = (i: number) => setOpenIndex(openIndex === i ? null : i);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsSubmitting(true);
     setSubmitMessage('');
-    
+
     try {
-      // Use Formspree to handle form submission
       const formspreeId = process.env.REACT_APP_FORMSPREE_ID || 'myyvklzv';
       const response = await fetch(`https://formspree.io/f/${formspreeId}`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           name: formData.name,
           email: formData.email,
           message: formData.question,
           _replyto: formData.email,
-          _subject: 'KOR FAQ Question'
+          _subject: 'KOR FAQ Question',
         }),
       });
-      
+
       if (response.ok) {
-        setSubmitMessage('Question submitted successfully! We\'ll respond within 24 hours.');
+        setSubmitMessage("Question submitted! We'll respond within 24 hours.");
         setFormData({ name: '', email: '', question: '' });
       } else {
         throw new Error(`HTTP error! status: ${response.status}`);
@@ -49,11 +76,10 @@ const FAQ: React.FC = () => {
     }
   };
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-    setFormData({
-      ...formData,
-      [e.target.name]: e.target.value
-    });
+  const handleChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    setFormData({ ...formData, [e.target.name]: e.target.value });
   };
 
   return (
@@ -64,84 +90,58 @@ const FAQ: React.FC = () => {
         pageDescription="Answers to common questions about KOR, personal plans, shop accounts, and getting started."
         url={`${baseUrl}/faq`}
       />
-      <h1 style={{ color: 'black' }}>Frequently Asked Questions</h1>
-      <div className="FAQ">
-        <h2>Q:</h2>
-        <h3 className="question">
-          I just bought a used bike, how can I track that bike accurately?
-        </h3>
-        <h2>A:</h2>
-        <h3 className="answer">
-          The app has a "Part Settings" settings page where you can manually set
-          the wear percentage for used parts. We recommend having a bike shop
-          estimate the condition of your components for the most accurate
-          tracking.
-        </h3>
-        
-        <h2>Q:</h2>
-        <h3 className="question">Can I use this app without a shop?</h3>
-        <h2>A:</h2>
-        <h3 className="answer">
-          Absolutely! You can purchase a personal account plan or use our free
-          limited version. However, we highly recommend getting a shop code from
-          a participating bike shop as it unlocks additional features and
-          enhanced support.
-        </h3>
-        
-        <h2>Q:</h2>
-        <h3 className="question">
-          I signed up for a personal account and lost my code before entering it
-          in the app. How can I get the code?
-        </h3>
-        <h2>A:</h2>
-        <h3 className="answer">
-          No problem! Contact us via email with your account information, and
-          we'll help you retrieve your personal account code.
-        </h3>
-        
-        <h2>Q:</h2>
-        <h3 className="question">
-          What if I do not have all of the parts on my bike, like front fork,
-          rear shock, sealant, or a dropper seatpost?
-        </h3>
-        <h2>A:</h2>
-        <h3 className="answer">
-          KOR is flexible! Use the bike settings page to customize which
-          components you want to track based on your specific bike setup. You
-          can easily add or remove parts like suspension, dropper posts, and
-          tubeless sealant.
-        </h3>
-        
-        <h2>Q:</h2>
-        <h3 className="question">How do I use the QR code system?</h3>
-        <h2>A:</h2>
-        <h3 className="answer">
-          Our QR code system makes it easy for bike shops to onboard new
-          customers. Simply have your customers scan the QR code, and they will
-          be automatically redirected to the app store with your shop code
-          pre-filled for instant login.
-        </h3>
-      </div>
-      
-      <h1><span style={{ color: 'black' }}>If you have any questions</span></h1>
-      <div className="FAQ">
+
+      <section className="faq-page-hero">
+        <h1 className="faq-page-title">Frequently Asked Questions</h1>
+        <p className="faq-page-subtitle">
+          Quick answers to the most common questions about KOR.
+        </p>
+      </section>
+
+      <section className="faq-section">
+        <div className="faq-accordion" role="list">
+          {faqs.map((item, i) => (
+            <div
+              key={i}
+              className={`faq-accordion-item ${openIndex === i ? 'open' : ''}`}
+              role="listitem"
+            >
+              <button
+                className="faq-trigger"
+                onClick={() => toggle(i)}
+                aria-expanded={openIndex === i}
+              >
+                <span className="faq-trigger-text">{item.question}</span>
+                <span className="faq-trigger-icon" aria-hidden="true">
+                  {openIndex === i ? '−' : '+'}
+                </span>
+              </button>
+              <div className="faq-panel">
+                <p className="faq-panel-text">{item.answer}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="faq-ask-section">
+        <h2 className="faq-ask-title">Still have a question?</h2>
+        <p className="faq-ask-subtitle">
+          Send it our way and we'll get back to you within 24 hours.
+        </p>
+
         {submitMessage && (
-          <div className={`form-message ${submitMessage.includes('Error') ? 'error' : 'success'}`} style={{ 
-            marginBottom: '1rem', 
-            padding: '0.75rem', 
-            borderRadius: '4px', 
-            backgroundColor: submitMessage.includes('Error') ? '#ffe6e6' : '#e6f7e6',
-            color: submitMessage.includes('Error') ? '#d63031' : '#00b894',
-            border: `1px solid ${submitMessage.includes('Error') ? '#d63031' : '#00b894'}`
-          }}>
+          <div
+            className={`form-message ${
+              submitMessage.includes('Error') ? 'error' : 'success'
+            }`}
+          >
             {submitMessage}
           </div>
         )}
+
         <form
-          action="https://formspree.io/f/myyvklzv"
-          method="post"
-          name="EmailForm"
-          className="login_form"
+          className="faq-ask-form"
           onSubmit={handleSubmit}
         >
           <div className="form_line">
@@ -150,7 +150,7 @@ const FAQ: React.FC = () => {
               type="text"
               id="name"
               name="name"
-              placeholder="first name/last name"
+              placeholder="First name / Last name"
               value={formData.name}
               onChange={handleChange}
               required
@@ -173,19 +173,18 @@ const FAQ: React.FC = () => {
             <textarea
               id="question"
               name="question"
-              placeholder="Please describe your question or concern in detail..."
+              placeholder="Describe your question or concern..."
               rows={4}
               value={formData.question}
               onChange={handleChange}
               required
             />
           </div>
-
           <button className="btn" type="submit" disabled={isSubmitting}>
             {isSubmitting ? 'Sending...' : 'Send Question'}
           </button>
         </form>
-      </div>
+      </section>
     </main>
   );
 };

--- a/kor-react/src/components/pages/Home.tsx
+++ b/kor-react/src/components/pages/Home.tsx
@@ -3,6 +3,9 @@ import { Link } from 'react-router-dom';
 import StructuredData from '../common/StructuredData';
 import { trackAppDownload } from '../common/GoogleAnalytics';
 import CountUp from '../common/CountUp';
+import SplitText from '../common/SplitText';
+import GlareHover from '../common/GlareHover';
+import DotField from '../common/DotField';
 
 const Home: React.FC = () => {
   const baseUrl = process.env.REACT_APP_SITE_URL || 'https://jmrcycling.com';
@@ -25,7 +28,9 @@ const Home: React.FC = () => {
                   alt="App Logo"
                 />
               </div>
-              <h1 id="hero-title" className="title_box">KOR (Keep On Rolling)</h1>
+              <h1 id="hero-title" className="title_box">
+                <SplitText text="KOR (Keep On Rolling)" delay={200} stagger={80} duration={700} />
+              </h1>
               <div className="cta-section">
                 <p className="cta-heading">Get Started Today - Free Download!</p>
                 <p className="paragraph">Show up for every ride with a bike that's ready to roll.</p>
@@ -81,6 +86,30 @@ const Home: React.FC = () => {
         </div>
       </section>
 
+      <section className="stats-row" aria-label="KOR by the numbers">
+        <DotField />
+        <div className="stats-row-inner">
+          <div className="stat-item">
+            <span className="stat-number">
+              <CountUp to={5200} duration={1800} />+
+            </span>
+            <span className="stat-label">rides synced</span>
+          </div>
+          <div className="stat-divider" aria-hidden="true" />
+          <div className="stat-item">
+            <span className="stat-number">
+              <CountUp to={18500} duration={2000} />+
+            </span>
+            <span className="stat-label">components tracked</span>
+          </div>
+          <div className="stat-divider" aria-hidden="true" />
+          <div className="stat-item">
+            <span className="stat-number">Free</span>
+            <span className="stat-label">to download, always</span>
+          </div>
+        </div>
+      </section>
+
       <section className="features-section wear-demo-section" aria-labelledby="features-title">
         <div className="parallax_parent">
           <div className="parallax2_home">
@@ -91,36 +120,42 @@ const Home: React.FC = () => {
                 can see exactly when to service before something breaks on the trail.
               </p>
               <div className="wear-demo-grid" role="list">
-                <article className="wear-card wear-card--warn" role="listitem">
-                  <div className="wear-card-header">
-                    <span className="wear-component-name">Chain</span>
-                    <span className="wear-badge wear-badge--warn">Replace Soon</span>
-                  </div>
-                  <div className="wear-bar-track">
-                    <div className="wear-bar-fill wear-bar-fill--warn" style={{ width: '81%' }} />
-                  </div>
-                  <CountUp to={81} suffix="%" className="wear-pct" />
-                </article>
-                <article className="wear-card wear-card--good" role="listitem">
-                  <div className="wear-card-header">
-                    <span className="wear-component-name">Brake Pads</span>
-                    <span className="wear-badge wear-badge--good">Good</span>
-                  </div>
-                  <div className="wear-bar-track">
-                    <div className="wear-bar-fill wear-bar-fill--good" style={{ width: '45%' }} />
-                  </div>
-                  <CountUp to={45} suffix="%" className="wear-pct" duration={1600} />
-                </article>
-                <article className="wear-card wear-card--good" role="listitem">
-                  <div className="wear-card-header">
-                    <span className="wear-component-name">Cassette</span>
-                    <span className="wear-badge wear-badge--good">Good</span>
-                  </div>
-                  <div className="wear-bar-track">
-                    <div className="wear-bar-fill wear-bar-fill--good" style={{ width: '28%' }} />
-                  </div>
-                  <CountUp to={28} suffix="%" className="wear-pct" duration={1800} />
-                </article>
+                <GlareHover className="wear-card wear-card--warn" style={{ borderRadius: '8px' }}>
+                  <article role="listitem">
+                    <div className="wear-card-header">
+                      <span className="wear-component-name">Chain</span>
+                      <span className="wear-badge wear-badge--warn">Replace Soon</span>
+                    </div>
+                    <div className="wear-bar-track">
+                      <div className="wear-bar-fill wear-bar-fill--warn" style={{ width: '81%' }} />
+                    </div>
+                    <CountUp to={81} suffix="%" className="wear-pct" />
+                  </article>
+                </GlareHover>
+                <GlareHover className="wear-card wear-card--good" style={{ borderRadius: '8px' }}>
+                  <article role="listitem">
+                    <div className="wear-card-header">
+                      <span className="wear-component-name">Brake Pads</span>
+                      <span className="wear-badge wear-badge--good">Good</span>
+                    </div>
+                    <div className="wear-bar-track">
+                      <div className="wear-bar-fill wear-bar-fill--good" style={{ width: '45%' }} />
+                    </div>
+                    <CountUp to={45} suffix="%" className="wear-pct" duration={1600} />
+                  </article>
+                </GlareHover>
+                <GlareHover className="wear-card wear-card--good" style={{ borderRadius: '8px' }}>
+                  <article role="listitem">
+                    <div className="wear-card-header">
+                      <span className="wear-component-name">Cassette</span>
+                      <span className="wear-badge wear-badge--good">Good</span>
+                    </div>
+                    <div className="wear-bar-track">
+                      <div className="wear-bar-fill wear-bar-fill--good" style={{ width: '28%' }} />
+                    </div>
+                    <CountUp to={28} suffix="%" className="wear-pct" duration={1800} />
+                  </article>
+                </GlareHover>
               </div>
               <p className="wear-demo-footnote">
                 All tracking happens automatically — no manual logging, no guesswork.

--- a/kor-react/src/components/pages/Home.tsx
+++ b/kor-react/src/components/pages/Home.tsx
@@ -27,7 +27,7 @@ const Home: React.FC = () => {
               <h1 id="hero-title" className="title_box">KOR (Keep On Rolling)</h1>
               <div className="cta-section">
                 <p className="cta-heading">Get Started Today - Free Download!</p>
-                <p className="paragraph">Show up for every ride with a bike that’s ready to roll.</p>
+                <p className="paragraph">Show up for every ride with a bike that's ready to roll.</p>
                 <div className="app-store-buttons">
                   <a
                     href="https://play.google.com/store/apps/details?id=com.robtuft.newKOR"
@@ -57,79 +57,73 @@ const Home: React.FC = () => {
                   </a>
                 </div>
                 <div className="secondary-cta">
-                  <p className="cta-subtext">Don't have a bike shop? No problem!</p>
                   <Link className="personal-cta-button" to="/personal-plans">
-                    KOR’s personal plans keep your maintenance dialed in wherever you 
-                    ride, so you get pro-level tracking without needing a dedicated 
-                    mechanic. → 
+                    No bike shop? Try personal plans →
                   </Link>
                 </div>
                 <p className="cta-trust-signal">
-                  Free to download · Secure Strava integration
+                  Free to download &middot; Secure Strava integration
                 </p>
               </div>
 
               <div className="mobile_textbox">
                 <h2 className="hero-subtitle">
-                    Spend less time worrying about maintenance and more time enjoying the 
-                    ride.
+                  Spend less time worrying about maintenance and more time enjoying the ride.
                 </h2>
                 <p className="paragraph">
-                  Keep On Rolling is a bike maintenance app that tracks your component
-                  wear from your Strava rides and alerts you before parts fail, so you
-                  never miss a ride to a broken bike again.
+                  KOR tracks your bike component wear from your Strava rides and alerts
+                  you before parts fail, so you never miss a ride to a broken bike again.
                 </p>
-                <div className="key-benefits">
-                  <div className="benefit-point">
-                    <strong>Smart Tracking:</strong> Automatically monitors component wear
-                  </div>
-                  <div className="benefit-point">
-                    <strong>Strava Integration:</strong> Uses your ride data
-                  </div>
-                  <div className="benefit-point">
-                    <strong>Proactive Alerts:</strong> Know before parts fail
-                  </div>
-                </div>
               </div>
             </div>
           </div>
         </div>
       </section>
 
-      <section className="features-section" aria-labelledby="features-title">
+      <section className="features-section wear-demo-section" aria-labelledby="features-title">
         <div className="parallax_parent">
           <div className="parallax2_home">
             <div style={{ padding: '5%' }}>
-              <h2 id="features-title">Why Choose KOR?</h2>
-              <div className="point-content" role="list">
-                <article className="point-card" role="listitem">
-                  <h3 className="title">Dedicated Support</h3>
-                  <p className="paragraph-on-dark">
-                    Get personal help from our founders. We're passionate
-                    cyclists who understand your needs and are here to ensure
-                    you have the best experience with KOR.
-                  </p>
-                  <Link className="point-link" to="/contact">
-                    Contact Us
-                  </Link>
+              <h2 id="features-title" className="wear-demo-heading">Know before it fails.</h2>
+              <p className="wear-demo-subheading">
+                KOR reads your Strava ride data and calculates real component wear so you
+                can see exactly when to service before something breaks on the trail.
+              </p>
+              <div className="wear-demo-grid" role="list">
+                <article className="wear-card wear-card--warn" role="listitem">
+                  <div className="wear-card-header">
+                    <span className="wear-component-name">Chain</span>
+                    <span className="wear-badge wear-badge--warn">Replace Soon</span>
+                  </div>
+                  <div className="wear-bar-track">
+                    <div className="wear-bar-fill wear-bar-fill--warn" style={{ width: '81%' }} />
+                  </div>
+                  <span className="wear-pct">81%</span>
                 </article>
-                <article className="point-card" role="listitem">
-                  <h3 className="title">Simple & Intuitive</h3>
-                  <p className="paragraph-on-dark">
-                    Simple, intuitive design built by riders means no complicated 
-                    setup—just ride and KOR handles the tracking.
-                  </p>
+                <article className="wear-card wear-card--good" role="listitem">
+                  <div className="wear-card-header">
+                    <span className="wear-component-name">Brake Pads</span>
+                    <span className="wear-badge wear-badge--good">Good</span>
+                  </div>
+                  <div className="wear-bar-track">
+                    <div className="wear-bar-fill wear-bar-fill--good" style={{ width: '45%' }} />
+                  </div>
+                  <span className="wear-pct">45%</span>
                 </article>
-                <article className="point-card" role="listitem">
-                  <h3 className="title">Stay Ride-Ready</h3>
-                  <p className="paragraph-on-dark">
-                    Peak riding season shouldn’t be ruined by preventable mechanical 
-                    problems. Advanced algorithms predict when components need attention,
-                    so you can ride with confidence knowing KOR is watching your 
-                    components for you.
-                  </p>
+                <article className="wear-card wear-card--good" role="listitem">
+                  <div className="wear-card-header">
+                    <span className="wear-component-name">Cassette</span>
+                    <span className="wear-badge wear-badge--good">Good</span>
+                  </div>
+                  <div className="wear-bar-track">
+                    <div className="wear-bar-fill wear-bar-fill--good" style={{ width: '28%' }} />
+                  </div>
+                  <span className="wear-pct">28%</span>
                 </article>
               </div>
+              <p className="wear-demo-footnote">
+                All tracking happens automatically — no manual logging, no guesswork.
+              </p>
             </div>
           </div>
         </div>

--- a/kor-react/src/components/pages/Home.tsx
+++ b/kor-react/src/components/pages/Home.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import StructuredData from '../common/StructuredData';
 import { trackAppDownload } from '../common/GoogleAnalytics';
+import CountUp from '../common/CountUp';
 
 const Home: React.FC = () => {
   const baseUrl = process.env.REACT_APP_SITE_URL || 'https://jmrcycling.com';
@@ -98,7 +99,7 @@ const Home: React.FC = () => {
                   <div className="wear-bar-track">
                     <div className="wear-bar-fill wear-bar-fill--warn" style={{ width: '81%' }} />
                   </div>
-                  <span className="wear-pct">81%</span>
+                  <CountUp to={81} suffix="%" className="wear-pct" />
                 </article>
                 <article className="wear-card wear-card--good" role="listitem">
                   <div className="wear-card-header">
@@ -108,7 +109,7 @@ const Home: React.FC = () => {
                   <div className="wear-bar-track">
                     <div className="wear-bar-fill wear-bar-fill--good" style={{ width: '45%' }} />
                   </div>
-                  <span className="wear-pct">45%</span>
+                  <CountUp to={45} suffix="%" className="wear-pct" duration={1600} />
                 </article>
                 <article className="wear-card wear-card--good" role="listitem">
                   <div className="wear-card-header">
@@ -118,7 +119,7 @@ const Home: React.FC = () => {
                   <div className="wear-bar-track">
                     <div className="wear-bar-fill wear-bar-fill--good" style={{ width: '28%' }} />
                   </div>
-                  <span className="wear-pct">28%</span>
+                  <CountUp to={28} suffix="%" className="wear-pct" duration={1800} />
                 </article>
               </div>
               <p className="wear-demo-footnote">

--- a/kor-react/src/components/pages/OurApp.tsx
+++ b/kor-react/src/components/pages/OurApp.tsx
@@ -40,6 +40,7 @@ const OurApp: React.FC = () => {
       <section className="app-screen-section">
         <div className="app-content-grid">
           <div className="our_app_textbox slide-in">
+            <h2 className="app-section-label">Your ride, at a glance</h2>
             <p className="paragraph">
               See which parts need attention next at a glance, so you can fix issues before they ruin a ride.
             </p>
@@ -57,6 +58,7 @@ const OurApp: React.FC = () => {
       <section className="app-screen-section">
         <div className="app-content-grid">
           <div className="our_app_textbox slide-in">
+            <h2 className="app-section-label">Full part history</h2>
             <p className="paragraph">
               View complete part history and update details in seconds, so you always know when each component was last serviced.
             </p>
@@ -74,8 +76,9 @@ const OurApp: React.FC = () => {
       <section className="app-screen-section">
         <div className="app-content-grid">
           <div className="our_app_textbox slide-in">
+            <h2 className="app-section-label">Built for your setup</h2>
             <p className="paragraph">
-              Track shock setup, customize parts, and set your default bike—keep all your ride data organized in one place.
+              Track shock setup, customize parts, and set your default bike — keep all your ride data organized in one place.
             </p>
           </div>
           <div className="center slide-in">
@@ -91,6 +94,7 @@ const OurApp: React.FC = () => {
       <section className="app-screen-section">
         <div className="app-content-grid">
           <div className="our_app_textbox slide-in">
+            <h2 className="app-section-label">Track only what you have</h2>
             <p className="paragraph">
               Show or hide parts based on what's actually on your bike, so your dashboard stays clutter-free and relevant.
             </p>
@@ -108,6 +112,7 @@ const OurApp: React.FC = () => {
       <section className="app-screen-section">
         <div className="app-content-grid">
           <div className="our_app_textbox slide-in">
+            <h2 className="app-section-label">Tuned to how you ride</h2>
             <p className="paragraph">
               Adjust wear percentages and lifespan estimates to match your riding style, so alerts fit how you actually use your bike.
             </p>

--- a/kor-react/src/components/pages/OurStory.tsx
+++ b/kor-react/src/components/pages/OurStory.tsx
@@ -14,31 +14,33 @@ const OurStory: React.FC = () => {
       <div className="parallax_parent">
         <div className="parallax_our_story">
           <div style={{ padding: '5%' }}>
-            <div className="mobile_textbox" style={{ opacity: 0.75 }}>
+            <div className="mobile_textbox">
               <h1>Our Story</h1>
-              <h3 className="paragraph">
+              <p className="paragraph">
                 We began with an idea to address the inconvenience of waiting
                 weeks for bike parts due to supply chain issues. Jessica Wyman
                 initially conceived this idea and later collaborated with Mason
                 Tuft and Robert Tuft to develop an app to solve this problem. We
-                started working on this project back in June 2020, and it has
+                started working on this project back in June 2020 — and it has
                 been a long journey, but we are thrilled to present our app to
-                you now!
-              </h3>
+                you now.
+              </p>
             </div>
           </div>
         </div>
       </div>
       <div className="parallax_parent">
         <div className="parallax2_our_story">
-          <div style={{ padding: '20%' }}>
-            <div className="mobile_textbox" style={{ opacity: 0.75 }}>
+          <div style={{ padding: '5%' }}>
+            <div className="mobile_textbox">
               <h1>Our Audience</h1>
-              <h3 className="paragraph">
-                We had this App originally tailored to high school mountain bike
-                racers. We have recently adapted to other types of riders from
-                hobbyists to pro racers!
-              </h3>
+              <p className="paragraph">
+                KOR started as a tool for high school mountain bike racers who
+                needed to stay on top of their components without a dedicated
+                mechanic. Since then we've grown to serve everyone from weekend
+                hobbyists to competitive racers — anyone who wants to spend more
+                time riding and less time guessing when to wrench.
+              </p>
             </div>
           </div>
         </div>

--- a/kor-react/src/components/pages/PersonalPlans.tsx
+++ b/kor-react/src/components/pages/PersonalPlans.tsx
@@ -69,7 +69,7 @@ const PersonalPlans: React.FC = () => {
       <div className='parallax_parent'>
         <div className='parallax_sign_up'>
           <div style={{ padding: '5%' }}>
-            <h1 className='title_box'>Personal Account Plans</h1>
+            <h1 className='plans-hero-title'>Personal Account Plans</h1>
             <div className='mobile_textbox'>
               <p className='paragraph'>
                 Perfect for individual cyclists who want to track their bike

--- a/kor-react/src/styles/styles.css
+++ b/kor-react/src/styles/styles.css
@@ -96,8 +96,6 @@
 .cta-section {
   text-align: center;
   padding: 1.5em;
-  background-color: rgba(0, 0, 0, 0.4);
-  border-radius: 15px;
   margin-top: 2em;
 }
 
@@ -885,6 +883,129 @@ select:focus {
 .benefit-point strong {
   color: var(--accent1-color);
 }
+
+/* ── Component Wear Demo (homepage features replacement) ── */
+.wear-demo-section {
+  margin-top: 0;
+  padding-top: 0;
+}
+.wear-demo-section .parallax2_home {
+  min-height: 520px !important;
+  padding: 60px 0;
+}
+.wear-demo-heading {
+  color: white;
+  font-family: var(--heading-font);
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  margin-bottom: 0.4em;
+  text-shadow: 0 2px 12px rgba(0,0,0,0.6);
+}
+
+.wear-demo-subheading {
+  color: rgba(255,255,255,0.85);
+  font-family: var(--paragraph-font);
+  font-size: 1.1rem;
+  max-width: 560px;
+  margin: 0 auto 2.5em;
+  line-height: 1.6;
+}
+
+.wear-demo-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+  max-width: 860px;
+  margin: 0 auto;
+}
+
+.wear-card {
+  background: rgba(14, 22, 34, 0.92);
+  backdrop-filter: blur(12px);
+  border-radius: 8px;
+  padding: 20px 20px 16px;
+  border: 1px solid rgba(255,255,255,0.14);
+  text-align: left;
+}
+
+.wear-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 14px;
+}
+
+.wear-component-name {
+  color: white;
+  font-family: var(--heading-font);
+  font-size: 1.3rem;
+  letter-spacing: 0.02em;
+}
+
+.wear-badge {
+  font-family: var(--paragraph-font);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 3px 8px;
+  border-radius: 4px;
+  text-transform: uppercase;
+}
+
+.wear-badge--warn {
+  background-color: rgba(232, 130, 26, 0.2);
+  color: #E8821A;
+  border: 1px solid rgba(232, 130, 26, 0.4);
+}
+
+.wear-badge--good {
+  background-color: rgba(103, 141, 88, 0.2);
+  color: #7db86a;
+  border: 1px solid rgba(103, 141, 88, 0.35);
+}
+
+.wear-bar-track {
+  width: 100%;
+  height: 6px;
+  background: rgba(255,255,255,0.12);
+  border-radius: 3px;
+  overflow: hidden;
+  margin-bottom: 8px;
+}
+
+.wear-bar-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 1s ease;
+}
+
+.wear-bar-fill--warn {
+  background-color: #E8821A;
+}
+
+.wear-bar-fill--good {
+  background-color: #678d58;
+}
+
+.wear-pct {
+  color: rgba(255,255,255,0.5);
+  font-family: var(--paragraph-font);
+  font-size: 0.85rem;
+}
+
+.wear-demo-footnote {
+  color: rgba(255,255,255,0.55);
+  font-family: var(--paragraph-font);
+  font-size: 0.9rem;
+  margin-top: 2em;
+  text-align: center;
+}
+
+@media (max-width: 700px) {
+  .wear-demo-grid {
+    grid-template-columns: 1fr;
+    max-width: 380px;
+  }
+}
 /* div {
     background-color: var(--accent3-color);
 } */
@@ -1145,15 +1266,15 @@ h1, h2 {
   color: white;
 }
 .title_box {
-  padding: 10px;
-  border-radius: 15px;
-  background-color: var(--primary-color);
   margin: 0 auto;
   width: fit-content;
   text-decoration: none;
-  color: var(--headline-color-on-dark);
-  font-family: var(--paragraph-font);
-
+  color: white;
+  font-family: var(--heading-font);
+  font-size: clamp(3rem, 8vw, 6rem);
+  letter-spacing: 0.01em;
+  line-height: 1;
+  text-shadow: 0 2px 24px rgba(0, 0, 0, 0.7), 0 1px 4px rgba(0, 0, 0, 0.9);
 }
 .title{
   text-align: center;

--- a/kor-react/src/styles/styles.css
+++ b/kor-react/src/styles/styles.css
@@ -2350,3 +2350,244 @@ a.payment-card2, a.payment-card3 {
     grid-template-columns: 1fr;
   }
 }
+
+/* ============================================================
+   FAQ PAGE
+   ============================================================ */
+
+.faq-page-hero {
+  background-color: var(--primary-color);
+  padding: 5rem 2rem 4rem;
+  text-align: center;
+}
+
+.faq-page-title {
+  font-family: var(--heading-font);
+  font-size: clamp(2.5rem, 6vw, 4.5rem);
+  color: #fff;
+  margin: 0 0 1rem;
+  text-shadow: 0 2px 16px rgba(0, 0, 0, 0.4);
+}
+
+.faq-page-subtitle {
+  font-family: var(--paragraph-font);
+  font-size: 1.15rem;
+  color: rgba(255, 255, 255, 0.8);
+  margin: 0;
+}
+
+.faq-section {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem;
+}
+
+.faq-accordion {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.faq-accordion-item {
+  border: 1px solid rgba(46, 64, 83, 0.15);
+  border-radius: 8px;
+  overflow: hidden;
+  background: #fff;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.05);
+  transition: box-shadow 0.2s ease;
+}
+
+.faq-accordion-item.open {
+  box-shadow: 0 4px 16px rgba(46, 64, 83, 0.12);
+}
+
+.faq-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: 1.25rem 1.5rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-align: left;
+  gap: 1rem;
+}
+
+.faq-trigger:hover {
+  background-color: rgba(46, 64, 83, 0.04);
+}
+
+.faq-trigger-text {
+  font-family: var(--paragraph-font);
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--primary-color);
+  line-height: 1.4;
+}
+
+.faq-trigger-icon {
+  flex-shrink: 0;
+  font-size: 1.4rem;
+  font-weight: 300;
+  color: var(--accent-color);
+  line-height: 1;
+}
+
+.faq-panel {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.3s ease, padding 0.3s ease;
+  padding: 0 1.5rem;
+}
+
+.faq-accordion-item.open .faq-panel {
+  max-height: 400px;
+  padding: 0 1.5rem 1.25rem;
+}
+
+.faq-panel-text {
+  font-family: var(--paragraph-font);
+  font-size: 1rem;
+  color: #444;
+  line-height: 1.7;
+  margin: 0;
+  border-top: 1px solid rgba(46, 64, 83, 0.1);
+  padding-top: 1rem;
+}
+
+/* FAQ ask form */
+.faq-ask-section {
+  background-color: var(--primary-color);
+  padding: 4rem 2rem;
+  text-align: center;
+}
+
+.faq-ask-title {
+  font-family: var(--heading-font);
+  font-size: clamp(2rem, 4vw, 3rem);
+  color: #fff;
+  margin: 0 0 0.5rem;
+}
+
+.faq-ask-subtitle {
+  font-family: var(--paragraph-font);
+  font-size: 1rem;
+  color: rgba(255, 255, 255, 0.75);
+  margin: 0 0 2rem;
+}
+
+.faq-ask-form {
+  max-width: 520px;
+  margin: 0 auto;
+  text-align: left;
+}
+
+.faq-ask-form .form_line label {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.faq-ask-form .form_line input,
+.faq-ask-form .form_line textarea {
+  background: rgba(255, 255, 255, 0.1);
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  color: #fff;
+  border-radius: 6px;
+}
+
+.faq-ask-form .form_line input::placeholder,
+.faq-ask-form .form_line textarea::placeholder {
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.faq-ask-form .btn {
+  width: 100%;
+  margin-top: 0.5rem;
+}
+
+/* ============================================================
+   OUR APP — section labels
+   ============================================================ */
+
+.app-section-label {
+  font-family: var(--heading-font);
+  font-size: clamp(1.4rem, 2.5vw, 2rem);
+  color: var(--headline-color-on-dark);
+  margin: 0 0 0.75rem;
+  letter-spacing: 0.01em;
+}
+
+/* ============================================================
+   PERSONAL PLANS — hero title (no pill)
+   ============================================================ */
+
+.plans-hero-title {
+  font-family: var(--heading-font);
+  font-size: clamp(2.5rem, 6vw, 5rem);
+  color: #fff;
+  text-shadow: 0 2px 24px rgba(0, 0, 0, 0.7);
+  margin: 0 0 1.5rem;
+}
+
+/* ============================================================
+   STATS ROW
+   ============================================================ */
+
+.stats-row {
+  position: relative;
+  background-color: var(--primary-color);
+  padding: 3.5rem 2rem;
+  overflow: hidden;
+}
+
+.stats-row-inner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0;
+  max-width: 860px;
+  margin: 0 auto;
+}
+
+.stat-item {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.4rem;
+  text-align: center;
+}
+
+.stat-number {
+  font-family: var(--heading-font);
+  font-size: clamp(2.2rem, 5vw, 3.5rem);
+  color: #fff;
+  line-height: 1;
+  letter-spacing: 0.01em;
+}
+
+.stat-label {
+  font-family: var(--paragraph-font);
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.65);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.stat-divider {
+  width: 1px;
+  height: 3rem;
+  background: rgba(255, 255, 255, 0.2);
+  flex-shrink: 0;
+}
+
+@media screen and (max-width: 600px) {
+  .stats-row-inner {
+    flex-direction: column;
+    gap: 2rem;
+  }
+  .stat-divider {
+    width: 3rem;
+    height: 1px;
+  }
+}


### PR DESCRIPTION
## Summary

- **New UI components**: Built `SplitText`, `GlareHover`, and `DotField` from scratch (inspired by reactbits.dev — all Pro-gated there, so custom implementations)
- **Homepage**: Animated hero title with word-by-word SplitText reveal; wear cards wrapped with mouse-tracking GlareHover; new stats row (rides synced / components tracked / Free to download) between hero and wear demo sections
- **FAQ page**: Complete rewrite from flat Q&A list to animated accordion with open/close state; added "Still have a question?" form section at bottom
- **Our App page**: Added descriptive `h2` headings to each of the 5 feature screen sections
- **Our Story page**: Removed opacity wash making text hard to read, fixed excessive padding on second section, expanded audience copy
- **Personal Plans page**: Removed `title_box` pill style from page heading — now a clean white League Gothic title

## Test plan

- [ ] Home — scroll through hero, observe SplitText word-reveal on load
- [ ] Home — hover wear cards and verify glare follows cursor; leave and verify fade-out
- [ ] Home — scroll to stats row, verify CountUp animations trigger
- [ ] FAQ — open/close accordion items; confirm only one item open at a time
- [ ] FAQ — verify "Still have a question?" section renders below accordion
- [ ] Our App — scroll through screen sections, verify section headings are present
- [ ] Our Story — verify text is fully opaque and readable on both sections
- [ ] Personal Plans — verify page title has no navy pill background
- [ ] Mobile (≤600px) — stats row stacks to single column; accordion and pages look correct

> **Note**: Stats row numbers (5,200 rides synced / 18,500 components tracked) are placeholders — update to real figures before merging if available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)