### PR TITLE
feat: instrument PostHog event tracking across signup, login, and shop flows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ deploy-*.log
 nginx.conf.sample
 login.txt
 .gstack/
+
+# Instagram automation (local-only, not part of the website)
+instagram_automation/

--- a/kor-react/.gitignore
+++ b/kor-react/.gitignore
@@ -21,3 +21,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.env

--- a/kor-react/src/components/pages/Contact.tsx
+++ b/kor-react/src/components/pages/Contact.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import StructuredData from '../common/StructuredData';
+import posthog from '../../lib/posthog';
 
 const Contact: React.FC = () => {
   const [formData, setFormData] = useState({
@@ -39,6 +40,10 @@ const Contact: React.FC = () => {
       });
       
       if (response.ok) {
+        posthog.capture('contact_message_submitted', {
+          subject: formData.subject || 'none',
+          message_length: formData.message.length
+        });
         setSubmitMessage('Message sent successfully! We\'ll get back to you within 24 hours.');
         setFormData({ name: '', email: '', subject: '', message: '' });
         setCharacterCount(0);
@@ -46,6 +51,7 @@ const Contact: React.FC = () => {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
     } catch (error) {
+      posthog.captureException(error as Error);
       console.error('Form submission error:', error);
       setSubmitMessage('Error sending message. Please check your connection and try again, or email us directly.');
     } finally {

--- a/kor-react/src/components/pages/FamilyPlanSignUp.tsx
+++ b/kor-react/src/components/pages/FamilyPlanSignUp.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
+import posthog from '../../lib/posthog';
 import {
   useLegacyParams,
   buildLegacyUrl,
@@ -284,6 +285,9 @@ const FamilyPlanSignUp: React.FC = () => {
       return;
     }
 
+    posthog.capture('family_signup_submitted', {
+      has_sub_id: !!params.sub_id
+    });
     setIsLoading(true);
 
     try {
@@ -316,6 +320,13 @@ const FamilyPlanSignUp: React.FC = () => {
       await createFamilyAccount(auth0UserId);
       console.log('👨‍👩‍👧‍👦 [FamilyPlanSignUp] Family account created on server');
 
+      posthog.identify(auth0UserId !== 'existing-user' ? auth0UserId : formData.email, {
+        email: formData.email,
+        family_name: formData.family_name,
+        account_type: 'family'
+      });
+      posthog.capture('family_signup_completed');
+
       // 4) Redirect to Auth0 login; user will log in using the password just created
       const redirectUri = window.location.origin + '/shop/login';
       console.log('🔐 [FamilyPlanSignUp] Redirecting to Auth0 login', {
@@ -328,6 +339,10 @@ const FamilyPlanSignUp: React.FC = () => {
         }
       });
     } catch (err: any) {
+      posthog.capture('family_signup_error', {
+        error_message: err?.message || 'unknown'
+      });
+      posthog.captureException(err as Error);
       console.error('❌ [FamilyPlanSignUp] Signup flow error', {
         message: err?.message,
         stack: err?.stack

--- a/kor-react/src/components/pages/SignUp.tsx
+++ b/kor-react/src/components/pages/SignUp.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import StructuredData from '../common/StructuredData';
+import posthog from '../../lib/posthog';
 
 const SignUp: React.FC = () => {
   const [demoFormData, setDemoFormData] = useState({
@@ -39,6 +40,11 @@ const SignUp: React.FC = () => {
       });
 
       if (response.ok) {
+        posthog.capture('demo_request_submitted', {
+          shop_name: demoFormData.shopName,
+          contact_name: demoFormData.contactName,
+          has_message: !!demoFormData.message.trim()
+        });
         setSubmitMessage(
           "Demo request submitted successfully! We'll contact you within 48 hours."
         );
@@ -53,6 +59,7 @@ const SignUp: React.FC = () => {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
     } catch (error) {
+      posthog.captureException(error as Error);
       console.error('Form submission error:', error);
       setSubmitMessage(
         'Error submitting request. Please try again or email us directly.'

--- a/kor-react/src/components/personal/PersonalSignIn.tsx
+++ b/kor-react/src/components/personal/PersonalSignIn.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { } from '@auth0/auth0-react';
 import LegacyAuthGuard from '../auth/LegacyAuthGuard';
 import { useLegacyParams, logLegacyParams } from '../../hooks/useLegacyParams';
+import posthog from '../../lib/posthog';
 
 interface FormData {
   name: string;
@@ -184,6 +185,10 @@ const PersonalSignIn: React.FC = () => {
       return;
     }
 
+    posthog.capture('personal_signup_submitted', {
+      has_plan_type: !!params.plan_type,
+      plan_type: params.plan_type || null
+    });
     setIsLoading(true);
 
     try {
@@ -246,12 +251,26 @@ const PersonalSignIn: React.FC = () => {
       sessionStorage.setItem('user_id', auth0UserId);
       console.log('💾 [PersonalSignIn] Session data stored');
 
+      posthog.identify(auth0UserId, {
+        email: formData.email,
+        name: formData.name,
+        plan_type: loginResult.plan_type[0].plan_type,
+        account_type: 'personal'
+      });
+      posthog.capture('personal_signup_completed', {
+        plan_type: loginResult.plan_type[0].plan_type
+      });
+
       // 5) Legacy redirect to QR onboard page
       const shopCode = loginResult.plan_type[0].shop_code;
       const onboardUrl = `${baseUrl}/qr/onboard/${shopCode}`;
       console.log('🎯 [PersonalSignIn] Redirecting to onboard URL', { onboardUrl });
       window.location.replace(onboardUrl);
     } catch (err: any) {
+      posthog.capture('personal_signup_error', {
+        error_message: err?.message || 'unknown'
+      });
+      posthog.captureException(err as Error);
       console.error('❌ [PersonalSignIn] Signup flow error', { message: err?.message, stack: err?.stack });
       const message =
         typeof err?.message === 'string' && err.message

--- a/kor-react/src/components/shop/SendNotificationsPanel.tsx
+++ b/kor-react/src/components/shop/SendNotificationsPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import posthog from '../../lib/posthog';
 
 interface SendState {
   sending: boolean;
@@ -52,9 +53,14 @@ const SendNotificationsPanel: React.FC = () => {
         throw new Error(text || `HTTP ${response.status}`);
       }
 
+      posthog.capture('notification_sent', {
+        shop_name,
+        message_length: message.trim().length
+      });
       setState({ sending: false, error: null, success: 'Your message has been sent to your customers.' });
       setMessage('');
     } catch (err) {
+      posthog.captureException(err as Error);
       const msg = err instanceof Error ? err.message : 'Unknown error';
       setState({ sending: false, error: msg, success: null });
     }

--- a/kor-react/src/components/shop/ShopLogin.tsx
+++ b/kor-react/src/components/shop/ShopLogin.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useCallback } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
 import { useNavigate } from 'react-router-dom';
 import { useLegacyParams, buildLegacyUrl } from '../../hooks/useLegacyParams';
+import posthog from '../../lib/posthog';
 
 const ShopLogin: React.FC = () => {
   const { loginWithRedirect, isAuthenticated, isLoading, error, user } =
@@ -64,6 +65,17 @@ const ShopLogin: React.FC = () => {
       sessionStorage.setItem('plan_type', result.plan_type[0].plan_type);
       sessionStorage.setItem('shop_token', result.plan_type[0].shop_token);
 
+      posthog.identify(user.sub || user.email || 'unknown', {
+        email: user.email,
+        shop_name: result.plan_type[0].shop_name,
+        shop_code: result.plan_type[0].shop_code,
+        plan_type: result.plan_type[0].plan_type
+      });
+      posthog.capture('shop_login_completed', {
+        shop_name: result.plan_type[0].shop_name,
+        plan_type: result.plan_type[0].plan_type
+      });
+
       // Store the viewer's identity at login time, while Auth0 is still active.
       // On subsequent page loads Auth0 silent auth often fails (e.g. localhost / 3rd-party cookies),
       // so we can't rely on auth0User being populated later.
@@ -116,6 +128,7 @@ const ShopLogin: React.FC = () => {
   ]);
 
   const handleLogin = async () => {
+    posthog.capture('shop_login_initiated');
     console.log('🚀 [ShopLogin] Login initiated:', {
       currentUrl: window.location.href,
       currentParams: params,

--- a/kor-react/src/components/shop/ShopSignIn.tsx
+++ b/kor-react/src/components/shop/ShopSignIn.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useAuth0 } from '@auth0/auth0-react';
 import LegacyAuthGuard from '../auth/LegacyAuthGuard';
 import { useLegacyParams, buildLegacyUrl, logLegacyParams } from '../../hooks/useLegacyParams';
+import posthog from '../../lib/posthog';
 
 interface FormData {
   shop_name: string;
@@ -202,6 +203,10 @@ const ShopSignIn: React.FC = () => {
       return;
     }
 
+    posthog.capture('shop_signup_submitted', {
+      has_plan_type: !!params.plan_type,
+      plan_type: params.plan_type || null
+    });
     setIsLoading(true);
 
     try {
@@ -229,6 +234,16 @@ const ShopSignIn: React.FC = () => {
       await createShopAccount(auth0UserId);
       console.log('🏪 [ShopSignIn] Shop account created on server');
 
+      posthog.identify(auth0UserId, {
+        email: formData.email,
+        shop_name: formData.shop_name,
+        plan_type: params.plan_type || null,
+        account_type: 'shop'
+      });
+      posthog.capture('shop_signup_completed', {
+        plan_type: params.plan_type || null
+      });
+
       // 4) Redirect to Auth0 login; user will log in using the password just created
       const redirectUri = window.location.origin + '/shop/login';
       console.log('🔐 [ShopSignIn] Redirecting to Auth0 login', { redirectUri });
@@ -239,6 +254,10 @@ const ShopSignIn: React.FC = () => {
         }
       });
     } catch (err: any) {
+      posthog.capture('shop_signup_error', {
+        error_message: err?.message || 'unknown'
+      });
+      posthog.captureException(err as Error);
       console.error('❌ [ShopSignIn] Signup flow error', { message: err?.message, stack: err?.stack });
       const message =
         typeof err?.message === 'string' && err.message

--- a/kor-react/src/components/shop/WearBar/PartReplaceModal.tsx
+++ b/kor-react/src/components/shop/WearBar/PartReplaceModal.tsx
@@ -3,6 +3,7 @@ import { X, CheckCircle } from 'lucide-react';
 import { replacePart, addMileage } from '../services/partReplaceApi';
 import { getApiConfig } from '../services/shopMaintenanceApi';
 import { formatReplacedDate, isChainLike, ADD_MILES_AMOUNT, ADD_HOURS_AMOUNT } from './wearUtils';
+import posthog from '../../../lib/posthog';
 import {
   overlayStyle,
   contentStyle,
@@ -139,6 +140,14 @@ const PartReplaceModal: React.FC<PartReplaceModalProps> = ({
           brokenWorn: pendingAction.brokenWorn,
           extraBody,
         });
+        posthog.capture('part_replaced', {
+          part_type: part.partType,
+          part_label: part.label,
+          bike_name: part.bikeName,
+          wear_percent: part.wearPercent,
+          reason: pendingAction.brokenWorn,
+          unit: part.unit
+        });
         handleSuccess('replaced');
       } else {
         await addMileage({
@@ -150,9 +159,17 @@ const PartReplaceModal: React.FC<PartReplaceModalProps> = ({
           usedBodyKey: part.usedBodyKey,
           unit: part.unit,
         });
+        posthog.capture('mileage_added', {
+          part_type: part.partType,
+          part_label: part.label,
+          bike_name: part.bikeName,
+          unit: part.unit,
+          amount_added: part.unit === 'hours' ? ADD_HOURS_AMOUNT : ADD_MILES_AMOUNT
+        });
         handleSuccess('mileage_added');
       }
     } catch (err) {
+      posthog.captureException(err as Error);
       handleError(err);
     }
   };


### PR DESCRIPTION
## Summary
PostHog wizard-generated instrumentation adding 16 events across six files, covering every major user action:

| Event | Description | File |
|---|---|---|
| `demo_request_submitted` | Shop owner submits the demo request form on the Sign Up page | `src/components/pages/SignUp.tsx` |
| `shop_signup_submitted` | Shop owner submits the create-account form | `src/components/shop/ShopSignIn.tsx` |
| `shop_signup_completed` | Shop account creation succeeded, Auth0 redirect initiated | `src/components/shop/ShopSignIn.tsx` |
| `shop_signup_error` | Shop account creation failed | `src/components/shop/ShopSignIn.tsx` |
| `personal_signup_submitted` | Personal user submits the create-account form | `src/components/personal/PersonalSignIn.tsx` |
| `personal_signup_completed` | Personal account creation succeeded | `src/components/personal/PersonalSignIn.tsx` |
| `personal_signup_error` | Personal account creation failed | `src/components/personal/PersonalSignIn.tsx` |
| `family_signup_submitted` | Family plan user submits the create-account form | `src/components/pages/FamilyPlanSignUp.tsx` |
| `family_signup_completed` | Family account creation succeeded | `src/components/pages/FamilyPlanSignUp.tsx` |
| `family_signup_error` | Family account creation failed | `src/components/pages/FamilyPlanSignUp.tsx` |
| `shop_login_initiated` | Shop partner clicks Sign In to start Auth0 auth | `src/components/shop/ShopLogin.tsx` |
| `shop_login_completed` | Shop partner authenticated, data stored in session | `src/components/shop/ShopLogin.tsx` |
| `notification_sent` | Shop sends a push notification to linked customers | `src/components/shop/SendNotificationsPanel.tsx` |
| `part_replaced` | Shop replaces a customer's bike part via the wear bar modal | `src/components/shop/WearBar/PartReplaceModal.tsx` |
| `mileage_added` | Shop manually adds mileage/hours to a bike part | `src/components/shop/WearBar/PartReplaceModal.tsx` |
| `contact_message_submitted` | Visitor submits the contact form | `src/components/pages/Contact.tsx` |

Each signup flow also calls `posthog.identify()` after account creation to link the Auth0 user ID to future events, and `posthog.captureException()` was added to the error catch blocks in these flows.

Also updates `.gitignore`: `kor-react/.gitignore` now ignores `.env`, and the repo-root `.gitignore` now ignores `instagram_automation/` (unrelated local-only automation project, not part of the website).

## Dashboard & insights
- **Dashboard**: [Analytics basics (wizard)](https://us.posthog.com/project/228059/dashboard/1805840)
- **Insight**: [Signup Completions Over Time](https://us.posthog.com/project/228059/insights/4qMEoaU5)
- **Insight**: [Shop Signup Conversion Funnel](https://us.posthog.com/project/228059/insights/iCXer6BC)
- **Insight**: [Notifications Sent Over Time](https://us.posthog.com/project/228059/insights/arNhVDAJ)
- **Insight**: [Part Replacements & Mileage Added](https://us.posthog.com/project/228059/insights/fjJYMUZz)
- **Insight**: [Signup Errors Over Time](https://us.posthog.com/project/228059/insights/yLpxwX5z)

## Test plan / before merging
- [ ] Run a full production build (`npm run build`) and fix any lint/type errors
- [ ] Run the test suite — instrumented call sites may need updated mocks/fixtures
- [ ] Add `REACT_APP_POSTHOG_KEY` and `REACT_APP_POSTHOG_HOST` to `.env.example`
- [ ] Wire source-map upload into CI so production stack traces de-minify
- [ ] Confirm the returning-visitor path also calls `identify` — currently only fires on fresh signup/login; returning sessions bypassing these flows stay anonymous until they log in again via `ShopLogin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)