### PR TITLE
chore: address PostHog wizard's post-merge checklist

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -42,6 +42,19 @@ jobs:
             exit 1
           fi
 
+      - name: Upload source maps to PostHog
+        if: ${{ secrets.POSTHOG_CLI_API_KEY != '' }}
+        working-directory: kor-react
+        env:
+          POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}
+          POSTHOG_CLI_PROJECT_ID: ${{ secrets.POSTHOG_CLI_PROJECT_ID }}
+        run: |
+          npx --yes @posthog/cli@0.8.1 sourcemap process \
+            --directory build \
+            --release-name kor-website \
+            --release-version "${{ github.sha }}" \
+            --delete-after
+
       - name: Set up SSH
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/kor-react/.env.example
+++ b/kor-react/.env.example
@@ -8,6 +8,12 @@ REACT_APP_FORMSPREE_ID=your-formspree-id
 # Analytics (optional)
 REACT_APP_GA_TRACKING_ID=your-google-analytics-id
 
+# PostHog Configuration
+REACT_APP_POSTHOG_KEY=your-posthog-project-key
+REACT_APP_POSTHOG_HOST=https://us.i.posthog.com
+# Set to 'true' to enable PostHog in development, otherwise only runs in production
+REACT_APP_POSTHOG_ENABLED=false
+
 # Site URL (canonical)
 REACT_APP_SITE_URL=https://jmrcycling.com
 

--- a/kor-react/src/components/pages/FamilyPlanSignUp.tsx
+++ b/kor-react/src/components/pages/FamilyPlanSignUp.tsx
@@ -325,7 +325,9 @@ const FamilyPlanSignUp: React.FC = () => {
         family_name: formData.family_name,
         account_type: 'family'
       });
-      posthog.capture('family_signup_completed');
+      posthog.capture('family_signup_completed', {
+        plan_type: 'family'
+      });
 
       // 4) Redirect to Auth0 login; user will log in using the password just created
       const redirectUri = window.location.origin + '/shop/login';

--- a/kor-react/src/contexts/ShopAccess.tsx
+++ b/kor-react/src/contexts/ShopAccess.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useEffect, useMemo, useState, useCallback } from 'react';
+import posthog from '../lib/posthog';
 
 export type ShopStatus = 'active' | 'paused' | 'inactive' | 'cancelled' | string;
 
@@ -52,6 +53,15 @@ export function ShopAccessProvider({ children }: { children: React.ReactNode }) 
           setPlan(data.plan_type ?? null);
           setName(data.shop_name ?? null);
           setCode(data.shop_code ?? null);
+          // Restores identity for returning sessions — Auth0's user.sub/email aren't
+          // reliably available here (silent auth often fails), so shop_code is the
+          // only stable id we have on a page load that skipped ShopLogin.
+          if (data.shop_code) {
+            posthog.identify(data.shop_code, {
+              shop_name: data.shop_name ?? null,
+              plan_type: data.plan_type ?? null
+            });
+          }
         } else {
           // Unknown response -> do not gate
           setStatus('active');


### PR DESCRIPTION
## Summary
Follow-up to #46 — works through the "Verify before merging" checklist left by the PostHog setup wizard, after manually reviewing all 7 instrumented files (no automated build/test run was reliable in this environment; verified types and property references by hand against the installed `posthog-js` `.d.ts`).

- **`.env.example`**: documents `REACT_APP_POSTHOG_KEY`, `REACT_APP_POSTHOG_HOST`, `REACT_APP_POSTHOG_ENABLED`, matching what's already used in `kor-react/.env` and `lib/posthog.ts`.
- **Returning-visitor `identify()` gap**: `ShopAccessProvider.refresh()` (`kor-react/src/contexts/ShopAccess.tsx`) restores a shop session from `sessionStorage` on every page load, but never called `posthog.identify()` — so a returning shop user (who didn't just go through `ShopLogin`) stayed anonymous. Now identifies using `shop_code` as the stable id, since Auth0's `user.sub`/`email` aren't reliably available at this point (silent auth commonly fails on localhost / with 3rd-party-cookie blocking — see existing comment in `ShopLogin.tsx`). Note: this uses a different distinct ID than the Auth0-based identify at login time, so PostHog may see two "persons" for the same human unless merged later.
- **Event parity**: `family_signup_completed` now includes `plan_type: 'family'`, matching `shop_signup_completed`/`personal_signup_completed` which both include `plan_type`.
- **Source-map upload in CI**: added a step to `deploy-production.yml` running `npx @posthog/cli sourcemap process --directory build --delete-after` right after the build, before the rsync deploy step (so raw source maps never reach the public server). Gated on `secrets.POSTHOG_CLI_API_KEY` being set, so it's a no-op until you add that secret.

## Action needed from you
To activate source-map de-minification, add these repo secrets (Settings → Secrets and variables → Actions):
- `POSTHOG_CLI_API_KEY` — a PostHog personal API key with `error_tracking:write` scope
- `POSTHOG_CLI_PROJECT_ID` — your PostHog project ID (the number in `https://us.posthog.com/project/<id>`)

## Out of scope (flagged, not addressed here)
- `kor-react/.env` (with a real PostHog key) is already committed to git history from before this work — untracking it now wouldn't remove it from history. Let me know if you want that cleaned up / keys rotated separately.

## Test plan
- [ ] Confirm `.env.example` values match your actual PostHog project config
- [ ] After adding the two secrets, trigger a production deploy and confirm the "Upload source maps to PostHog" step runs and succeeds
- [ ] Spot-check in PostHog that a returning shop session (reload a page with an existing `shop_token` in sessionStorage, without re-logging-in) shows up identified rather than anonymous

🤖 Generated with [Claude Code](https://claude.com/claude-code)