### PR TITLE
fix: deploy workflow invalid due to secrets in step if:

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -51,7 +51,7 @@ jobs:
           fi
 
       - name: Upload source maps to PostHog
-        if: ${{ secrets.POSTHOG_CLI_API_KEY != '' }}
+        if: ${{ env.POSTHOG_CLI_API_KEY != '' }}
         working-directory: kor-react
         env:
           POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}


### PR DESCRIPTION
## Root cause
Every production deploy since #47 merged has failed instantly (0s, zero jobs run) — GitHub's Actions parser rejects the entire workflow file when a step's `if:` condition references the `secrets` context directly, which is exactly what the "Upload source maps to PostHog" step did:

```yaml
if: ${{ secrets.POSTHOG_CLI_API_KEY != '' }}
```

`secrets` is only available in `env`, `with`, and `run` — not `if:`. This isn't a YAML syntax error (confirmed the file parses fine with `js-yaml` and `action-validator`, and is byte-identical to what's in GitHub's git history) — it's a GitHub Actions-specific context-availability rule enforced separately from YAML/schema validation, which is why it silently produced zero jobs instead of a normal step failure.

## Fix
Route the secret through `env:` first (which does support `secrets`), then check the resulting env var in `if:` instead — this is GitHub's documented pattern for gating a step on an optional secret:

```yaml
if: ${{ env.POSTHOG_CLI_API_KEY != '' }}
env:
  POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}
```

Checked the rest of the repo's workflows — this was the only `secrets.*` reference inside an `if:`.

## Test plan
- [ ] Merge and confirm the next push to `main` produces a normal `deploy-production.yml` run (jobs actually execute) instead of an instant failure
- [ ] Confirm the site actually deploys/updates as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)