### PR TITLE
fix: don't let PostHog source-map upload block production deploy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Upload source maps to PostHog
         if: ${{ env.POSTHOG_CLI_API_KEY != '' }}
         working-directory: kor-react
+        continue-on-error: true
         env:
           POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}
           POSTHOG_CLI_PROJECT_ID: ${{ secrets.POSTHOG_CLI_PROJECT_ID }}


### PR DESCRIPTION
## Summary
- The "Deploy to Production" workflow was failing on every push to `main` because the "Upload source maps to PostHog" step errored with `Invalid Environment ID: "Environment ID must be a number"` (the `POSTHOG_CLI_PROJECT_ID` secret was set to a non-numeric value)
- Since that step runs before the SSH/rsync deploy steps, the misconfigured/failing analytics upload was blocking the entire production deployment
- Added `continue-on-error: true` to the source-map upload step so a broken or misconfigured PostHog upload can never again take down the actual site deployment — build, rsync, and health-check steps still run regardless

## Test plan
- [x] Validated the workflow YAML parses correctly
- [ ] Confirm the next push to `main` deploys successfully now that `POSTHOG_CLI_PROJECT_ID` has been corrected

https://claude.ai/code/session_0163ARtSeeJ76j6J6WSXaUKG


---
_Generated by [Claude Code](https://claude.ai/code/session_0163ARtSeeJ76j6J6WSXaUKG)_