### PR TITLE
fix: wire REACT_APP_API_AUTH_TOKEN into production build

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -37,6 +37,7 @@ jobs:
           REACT_APP_FORMSPREE_ID: ${{ vars.REACT_APP_FORMSPREE_ID }}
           REACT_APP_POSTHOG_KEY: ${{ vars.REACT_APP_POSTHOG_KEY }}
           REACT_APP_POSTHOG_HOST: ${{ vars.REACT_APP_POSTHOG_HOST }}
+          REACT_APP_API_AUTH_TOKEN: ${{ secrets.REACT_APP_API_AUTH_TOKEN }}
         run: npm run build
 
       - name: Verify build output


### PR DESCRIPTION
## Root cause
Reported error: logging into the shop dashboard as a test shop shows

> Error loading family members: Failed to load users (HTTP 403 {"message":"error","error":"Forbidden: Invalid auth token"})

`getApiConfig()` (`kor-react/src/components/shop/services/shopMaintenanceApi.ts:270`) reads `REACT_APP_API_AUTH_TOKEN` and sends it as the `auth` form field to `/getShopUsers` and related endpoints. That variable only ever lived in the local dev `.env` file — never in `.env.production`. Before #48 untracked those files, CRA's production build still picked it up as a fallback because `.env` was present in every CI checkout (CRA merges `.env` as a base across all environments). Once `.env` was untracked, production builds silently got an empty string for this token, and the backend correctly rejected it with 403.

Cross-checked every other `REACT_APP_*` reference in the codebase against the deploy workflow — this was the only real gap; everything else missing either has a working hardcoded fallback or was already unset in production before #48.

## Fix
`REACT_APP_API_AUTH_TOKEN` has been added as a GitHub Actions **secret** (not a variable, unlike the other config values — this one is a real backend auth token, not a public-by-design SPA/publishable key) and is now wired into the "Build React app" step in `deploy-production.yml`.

## Test plan
- [ ] Merge, let it deploy, and confirm the shop dashboard loads family members without the 403
- [ ] Spot-check other endpoints using the same auth token (e.g. maintenance reports) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)